### PR TITLE
Handle schedule API missing create method gracefully

### DIFF
--- a/src/tools/manage-entity/entity-handlers/schedule-handler.test.ts
+++ b/src/tools/manage-entity/entity-handlers/schedule-handler.test.ts
@@ -54,6 +54,30 @@ describe('ScheduleHandler', () => {
 
       spy.mockRestore();
     });
+
+    it('should surface unsupported feature error when API rejects with a string message', async () => {
+      const data = {
+        name: 'Test Schedule',
+        accountId: 'f6a5cc2a-5db0-4439-a738-99a539d5c580',
+        amount: 1000,
+        nextDate: '2025-12-01',
+        rule: 'every month',
+      };
+      const unsupportedResponse = {
+        isError: true,
+        content: [{ type: 'text', text: 'unsupported' }],
+      } as ReturnType<typeof EntityErrorBuilder.unsupportedFeature>;
+
+      vi.mocked(actualApi.createSchedule).mockRejectedValue(
+        'createSchedule method is not available in this version of the API'
+      );
+      const spy = vi.spyOn(EntityErrorBuilder, 'unsupportedFeature').mockReturnValue(unsupportedResponse);
+
+      await expect(scheduleHandler.create(data)).rejects.toBe(unsupportedResponse);
+      expect(spy).toHaveBeenCalledWith('schedule', 'create');
+
+      spy.mockRestore();
+    });
   });
 
   describe('update', () => {

--- a/src/tools/manage-entity/entity-handlers/schedule-handler.ts
+++ b/src/tools/manage-entity/entity-handlers/schedule-handler.ts
@@ -81,7 +81,9 @@ export class ScheduleHandler implements EntityHandler<ScheduleData, ScheduleData
   }
 
   private handleScheduleApiError(operation: Operation, error: unknown): never {
-    if (error instanceof Error && error.message.includes(API_UNAVAILABLE_ERROR_FRAGMENT)) {
+    const message = error instanceof Error ? error.message : typeof error === 'string' ? error : undefined;
+
+    if (message?.includes(API_UNAVAILABLE_ERROR_FRAGMENT)) {
       throw EntityErrorBuilder.unsupportedFeature('schedule', operation);
     }
 


### PR DESCRIPTION
### **User description**
## Summary
- normalize schedule handler error handling to detect missing API support even when rejection is a string
- add regression coverage for string-based API rejections to ensure unsupported feature responses are surfaced

## Testing
- npx vitest run src/tools/manage-entity/entity-handlers/schedule-handler.test.ts

------
https://chatgpt.com/codex/tasks/task_e_690ce930f3848333823cb0631429a808


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Normalize schedule handler error handling to detect missing API support from string rejections

- Add regression test coverage for string-based API rejection scenarios

- Improve error message extraction to handle both Error objects and string messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API Rejection"] --> B{"Error Type Check"}
  B -->|Error Object| C["Extract message property"]
  B -->|String| D["Use string directly"]
  C --> E["Check for API_UNAVAILABLE_ERROR_FRAGMENT"]
  D --> E
  E -->|Match Found| F["Throw unsupportedFeature error"]
  E -->|No Match| G["Throw original error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schedule-handler.ts</strong><dd><code>Improve error handling for string-based API rejections</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/manage-entity/entity-handlers/schedule-handler.ts

<ul><li>Modified <code>handleScheduleApiError</code> method to handle both Error objects <br>and string rejections<br> <li> Extracts error message from Error.message or uses string directly<br> <li> Checks extracted message for API_UNAVAILABLE_ERROR_FRAGMENT to detect <br>unsupported features</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/9/files#diff-b13bdb9fbe7d45479bb9e881e371486514f651b7e3f8d283a3f2757c32e0d0bd">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>schedule-handler.test.ts</strong><dd><code>Add test coverage for string rejection handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/manage-entity/entity-handlers/schedule-handler.test.ts

<ul><li>Added new test case for string-based API rejection scenario<br> <li> Tests that unsupported feature error is properly surfaced when API <br>rejects with string message<br> <li> Verifies EntityErrorBuilder.unsupportedFeature is called with correct <br>parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/9/files#diff-fc5d3c8da8c4af04777ce0a7cc1ccc6c2fa862b2d22c88b75fd26bcfb533ade6">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

