### PR TITLE
Fix account resolution and improve transaction reporting

### DIFF
--- a/src/core/data/fetch-transactions.test.ts
+++ b/src/core/data/fetch-transactions.test.ts
@@ -13,6 +13,12 @@ vi.mock('./fetch-categories.js', () => ({
   fetchAllCategories: vi.fn(),
 }));
 
+vi.mock('../utils/name-resolver.js', () => ({
+  nameResolver: {
+    resolveAccount: vi.fn(),
+  },
+}));
+
 import {
   fetchTransactionsForAccount,
   fetchAllOnBudgetTransactions,
@@ -23,10 +29,12 @@ import {
 import { getTransactions } from '../../actual-api.js';
 import { fetchAllPayees } from './fetch-payees.js';
 import { fetchAllCategories } from './fetch-categories.js';
+import { nameResolver } from '../utils/name-resolver.js';
 
 describe('fetchTransactionsForAccount', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.mocked(nameResolver.resolveAccount).mockImplementation(async (value: string) => value);
   });
 
   it('should return transactions for specific account with populated names', async () => {
@@ -58,6 +66,8 @@ describe('fetchTransactionsForAccount', () => {
       { id: 'c2', name: 'Fuel', group_id: 'g2' },
     ]);
 
+    vi.mocked(nameResolver.resolveAccount).mockResolvedValue('resolved-acc1');
+
     const result = await fetchTransactionsForAccount('acc1', '2023-01-01', '2023-01-31');
 
     expect(result).toEqual([
@@ -72,7 +82,8 @@ describe('fetchTransactionsForAccount', () => {
         category_name: 'Fuel',
       },
     ]);
-    expect(getTransactions).toHaveBeenCalledWith('acc1', '2023-01-01', '2023-01-31');
+    expect(nameResolver.resolveAccount).toHaveBeenCalledWith('acc1');
+    expect(getTransactions).toHaveBeenCalledWith('resolved-acc1', '2023-01-01', '2023-01-31');
     expect(fetchAllPayees).toHaveBeenCalledTimes(1);
     expect(fetchAllCategories).toHaveBeenCalledTimes(1);
   });
@@ -118,6 +129,16 @@ describe('fetchTransactionsForAccount', () => {
     expect(getTransactions).toHaveBeenCalledWith('acc1', '2023-01-01', '2023-01-31');
     expect(fetchAllPayees).not.toHaveBeenCalled();
     expect(fetchAllCategories).not.toHaveBeenCalled();
+  });
+
+  it('resolves account names before fetching transactions', async () => {
+    vi.mocked(nameResolver.resolveAccount).mockResolvedValue('acc-from-name');
+    vi.mocked(getTransactions).mockResolvedValue([]);
+
+    await fetchTransactionsForAccount('Checking', '2023-01-01', '2023-01-31');
+
+    expect(nameResolver.resolveAccount).toHaveBeenCalledWith('Checking');
+    expect(getTransactions).toHaveBeenCalledWith('acc-from-name', '2023-01-01', '2023-01-31');
   });
 });
 

--- a/src/core/data/fetch-transactions.ts
+++ b/src/core/data/fetch-transactions.ts
@@ -4,6 +4,7 @@ import { fetchAllCategories } from './fetch-categories.js';
 import { GroupAggregator } from '../aggregation/group-by.js';
 import type { Account, Transaction, Payee, Category } from '../types/domain.js';
 import { TransactionEntity } from '@actual-app/api/@types/loot-core/src/types/models/transaction.js';
+import { nameResolver } from '../utils/name-resolver.js';
 
 const groupAggregator = new GroupAggregator();
 
@@ -116,11 +117,17 @@ export async function enrichTransactionsBatch(
   return _enrichTransactions(transactions, actualLookups);
 }
 
+interface FetchTransactionsOptions {
+  accountIdIsResolved?: boolean;
+}
+
 export async function fetchTransactionsForAccount(
-  accountId: string,
+  accountIdOrName: string,
   start: string,
-  end: string
+  end: string,
+  options: FetchTransactionsOptions = {}
 ): Promise<Transaction[]> {
+  const accountId = options.accountIdIsResolved ? accountIdOrName : await nameResolver.resolveAccount(accountIdOrName);
   const transactions = await getTransactions(accountId, start, end);
   return _enrichTransactions(transactions);
 }

--- a/src/core/types/schemas.ts
+++ b/src/core/types/schemas.ts
@@ -19,7 +19,7 @@ export const GetTransactionsArgsSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Start date for transaction range in YYYY-MM-DD format (e.g., "2024-01-01"). If omitted, defaults to 30 days before endDate or today.'
+      'Start date for transaction range in YYYY-MM-DD format (e.g., "2024-01-01"). If omitted, defaults to 3 months before endDate or today.'
     ),
   endDate: z
     .string()

--- a/src/core/utils/account-selector.test.ts
+++ b/src/core/utils/account-selector.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Account } from '../types/domain.js';
+
+vi.mock('./name-resolver.js', () => ({
+  nameResolver: {
+    resolveAccount: vi.fn(),
+  },
+}));
+
+import { resolveAccountSelection } from './account-selector.js';
+import { nameResolver } from './name-resolver.js';
+
+describe('resolveAccountSelection', () => {
+  const accounts: Account[] = [
+    { id: 'acc-1', name: 'Checking', offbudget: false, closed: false },
+    { id: 'acc-2', name: 'Savings', offbudget: false, closed: false },
+  ];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns empty result when reference is undefined', async () => {
+    const result = await resolveAccountSelection(accounts, undefined);
+
+    expect(result).toEqual({});
+    expect(nameResolver.resolveAccount).not.toHaveBeenCalled();
+  });
+
+  it('resolves account name to matching account details', async () => {
+    vi.mocked(nameResolver.resolveAccount).mockResolvedValue('acc-1');
+
+    const result = await resolveAccountSelection(accounts, 'Checking');
+
+    expect(nameResolver.resolveAccount).toHaveBeenCalledWith('Checking');
+    expect(result).toEqual({ accountId: 'acc-1', account: accounts[0] });
+  });
+
+  it('returns resolved ID even when account is not present in list', async () => {
+    vi.mocked(nameResolver.resolveAccount).mockResolvedValue('acc-3');
+
+    const result = await resolveAccountSelection(accounts, 'Investment');
+
+    expect(nameResolver.resolveAccount).toHaveBeenCalledWith('Investment');
+    expect(result).toEqual({ accountId: 'acc-3', account: undefined });
+  });
+});

--- a/src/core/utils/account-selector.ts
+++ b/src/core/utils/account-selector.ts
@@ -1,0 +1,29 @@
+import type { Account } from '../types/domain.js';
+import { nameResolver } from './name-resolver.js';
+
+export interface ResolvedAccountSelection {
+  accountId?: string;
+  account?: Account;
+}
+
+/**
+ * Resolve an account reference (name or ID) against a provided account list.
+ * Returns both the resolved account ID and the matching account object when found.
+ *
+ * @param accounts - Cached list of accounts
+ * @param reference - Account name or ID supplied by the caller
+ * @returns Object containing the resolved account ID and matching account, if any
+ */
+export async function resolveAccountSelection(
+  accounts: Account[],
+  reference: string | undefined
+): Promise<ResolvedAccountSelection> {
+  if (!reference) {
+    return {};
+  }
+
+  const accountId = await nameResolver.resolveAccount(reference);
+  const account = accounts.find((candidate) => candidate.id === accountId);
+
+  return { accountId, account };
+}

--- a/src/tools/balance-history/data-fetcher.ts
+++ b/src/tools/balance-history/data-fetcher.ts
@@ -3,10 +3,11 @@ import { fetchAllAccounts } from '../../core/data/fetch-accounts.js';
 import { fetchAllTransactions, fetchTransactionsForAccount } from '../../core/data/fetch-transactions.js';
 import type { Account, Transaction } from '../../core/types/domain.js';
 import api from '@actual-app/api';
+import { resolveAccountSelection } from '../../core/utils/account-selector.js';
 
 export class BalanceHistoryDataFetcher {
   async fetchAll(
-    accountId: string | undefined,
+    accountReference: string | undefined,
     start: string,
     end: string
   ): Promise<{
@@ -15,17 +16,19 @@ export class BalanceHistoryDataFetcher {
     transactions: Transaction[];
   }> {
     const accounts = await fetchAllAccounts();
-    const account = accounts.find((a) => a.id === accountId);
+    const { accountId, account } = await resolveAccountSelection(accounts, accountReference);
 
     let transactions: Transaction[] = [];
     if (accountId && account) {
       // # Reason: Fetch transactions and balance in parallel for single account
       const [txs, balance] = await Promise.all([
-        fetchTransactionsForAccount(accountId, start, end),
+        fetchTransactionsForAccount(accountId, start, end, { accountIdIsResolved: true }),
         api.getAccountBalance(accountId),
       ]);
       transactions = txs;
       account.balance = balance;
+    } else if (accountId) {
+      transactions = await fetchTransactionsForAccount(accountId, start, end, { accountIdIsResolved: true });
     } else {
       // # Reason: Fetch transactions and all account balances in parallel
       const [txs, balances] = await Promise.all([

--- a/src/tools/get-transactions/data-fetcher.ts
+++ b/src/tools/get-transactions/data-fetcher.ts
@@ -2,8 +2,12 @@
 import { fetchTransactionsForAccount } from '../../core/data/fetch-transactions.js';
 import type { Transaction } from '../../core/types/domain.js';
 
+interface FetchOptions {
+  accountIdIsResolved?: boolean;
+}
+
 export class GetTransactionsDataFetcher {
-  async fetch(accountId: string, start: string, end: string): Promise<Transaction[]> {
-    return await fetchTransactionsForAccount(accountId, start, end);
+  async fetch(accountId: string, start: string, end: string, options: FetchOptions = {}): Promise<Transaction[]> {
+    return await fetchTransactionsForAccount(accountId, start, end, options);
   }
 }

--- a/src/tools/get-transactions/index.ts
+++ b/src/tools/get-transactions/index.ts
@@ -7,6 +7,7 @@ import { GetTransactionsReportGenerator } from './report-generator.js';
 import { success, errorFromCatch } from '../../core/response/index.js';
 import { getDateRange } from '../../utils.js';
 import { GetTransactionsArgsSchema, type GetTransactionsArgs } from '../../core/types/index.js';
+import { nameResolver } from '../../core/utils/name-resolver.js';
 import type { ToolInput } from '../../types.js';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 
@@ -17,7 +18,7 @@ export const schema = {
     'REQUIRED PARAMETERS:\n' +
     '- accountId: Account name or ID (use get-accounts to find account IDs)\n\n' +
     'OPTIONAL FILTERS:\n' +
-    '- startDate: Start date in YYYY-MM-DD format (defaults to 30 days ago if not specified)\n' +
+    '- startDate: Start date in YYYY-MM-DD format (defaults to 3 months ago if not specified)\n' +
     '- endDate: End date in YYYY-MM-DD format (defaults to today if not specified)\n' +
     '- minAmount: Minimum transaction amount in dollars (e.g., 50.00 for $50)\n' +
     '- maxAmount: Maximum transaction amount in dollars (e.g., 100.00 for $100)\n' +
@@ -35,7 +36,7 @@ export const schema = {
     '  {"accountId": "Checking", "categoryName": "Groceries", "startDate": "2024-01-01", "endDate": "2024-01-31"}\n' +
     '- Combined filters (category + amount range + limit):\n' +
     '  {"accountId": "Checking", "categoryName": "Dining", "minAmount": 20, "maxAmount": 100, "limit": 10}\n' +
-    '- All transactions from last 30 days (default):\n' +
+    '- All transactions from last 3 months (default):\n' +
     '  {"accountId": "Checking"}\n\n' +
     'COMMON USE CASES:\n' +
     '- Reviewing recent spending: Specify accountId and date range to see transactions in a period\n' +
@@ -46,7 +47,7 @@ export const schema = {
     'NOTES:\n' +
     '- Amounts in filters are in dollars (e.g., 50.00), but returned amounts are in cents\n' +
     '- Text filters (categoryName, payeeName) support partial matching for flexibility\n' +
-    '- If no date range is specified, defaults to last 30 days\n' +
+    '- If no date range is specified, defaults to the last 3 months\n' +
     '- Use get-accounts first if you need to find the correct account ID\n' +
     '- Filters are applied cumulatively (AND logic) - all specified filters must match\n\n' +
     'TYPICAL WORKFLOW:\n' +
@@ -70,8 +71,12 @@ export async function handler(args: GetTransactionsArgs): Promise<CallToolResult
     const { accountId, startDate, endDate, minAmount, maxAmount, categoryName, payeeName, limit } = input;
     const { startDate: start, endDate: end } = getDateRange(startDate, endDate);
 
+    const resolvedAccountId = await nameResolver.resolveAccount(accountId);
+
     // Fetch transactions
-    const transactions = await new GetTransactionsDataFetcher().fetch(accountId, start, end);
+    const transactions = await new GetTransactionsDataFetcher().fetch(resolvedAccountId, start, end, {
+      accountIdIsResolved: true,
+    });
     let filtered = [...transactions];
 
     if (minAmount !== undefined) {
@@ -96,22 +101,31 @@ export async function handler(args: GetTransactionsArgs): Promise<CallToolResult
     const mapped = new TransactionMapper().map(filtered);
 
     // Build filter description
-    const filterDescription = [
-      startDate || endDate ? `Date range: ${startDate} to ${endDate}` : null,
-      minAmount !== undefined ? `Min amount: $${minAmount.toFixed(2)}` : null,
-      maxAmount !== undefined ? `Max amount: $${maxAmount.toFixed(2)}` : null,
-      categoryName ? `Category: ${categoryName}` : null,
-      payeeName ? `Payee: ${payeeName}` : null,
-    ]
-      .filter(Boolean)
-      .join(', ');
+    const appliedFilters: string[] = [];
+    if (minAmount !== undefined) {
+      appliedFilters.push(`Minimum amount: $${minAmount.toFixed(2)}`);
+    }
+    if (maxAmount !== undefined) {
+      appliedFilters.push(`Maximum amount: $${maxAmount.toFixed(2)}`);
+    }
+    if (categoryName) {
+      appliedFilters.push(`Category contains: "${categoryName}"`);
+    }
+    if (payeeName) {
+      appliedFilters.push(`Payee contains: "${payeeName}"`);
+    }
+    if (limit !== undefined) {
+      appliedFilters.push(`Result limit: ${limit}`);
+    }
 
-    const markdown = new GetTransactionsReportGenerator().generate(
-      mapped,
-      filterDescription,
-      filtered.length,
-      transactions.length
-    );
+    const markdown = new GetTransactionsReportGenerator().generate(mapped, {
+      accountReference: accountId,
+      resolvedAccountId,
+      dateRange: { start, end },
+      appliedFilters,
+      filteredCount: filtered.length,
+      totalFetched: transactions.length,
+    });
     return success(markdown);
   } catch (err) {
     return errorFromCatch(err, {

--- a/src/tools/get-transactions/report-generator.ts
+++ b/src/tools/get-transactions/report-generator.ts
@@ -1,23 +1,48 @@
 // Generates the response/report for get-transactions tool
 
+interface TransactionRow {
+  id: string;
+  date: string;
+  payee: string;
+  category: string;
+  amount: string;
+  notes: string;
+}
+
+interface ReportMetadata {
+  accountReference: string;
+  resolvedAccountId: string;
+  dateRange: { start: string; end: string };
+  appliedFilters: string[];
+  filteredCount: number;
+  totalFetched: number;
+}
+
 export class GetTransactionsReportGenerator {
-  generate(
-    mappedTransactions: Array<{
-      id: string;
-      date: string;
-      payee: string;
-      category: string;
-      amount: string;
-      notes: string;
-    }>,
-    filterDescription: string,
-    filteredCount: number,
-    totalCount: number
-  ): string {
-    const header = '| ID | Date | Payee | Category | Amount | Notes |\n| ---- | ----- | -------- | ------ | ----- |\n';
+  generate(mappedTransactions: TransactionRow[], metadata: ReportMetadata): string {
+    const header =
+      '| ID | Date | Payee | Category | Amount | Notes |\n| ---- | ----- | -------- | ------ | ----- | ----- |\n';
     const rows = mappedTransactions
       .map((t) => `| ${t.id} | ${t.date} | ${t.payee} | ${t.category} | ${t.amount} | ${t.notes} |`)
       .join('\n');
-    return `# Filtered Transactions\n\n${filterDescription}\nMatching Transactions: ${filteredCount}/${totalCount}\n\n${header}${rows}`;
+
+    const table = rows.length > 0 ? `${header}${rows}` : `${header}| _No matching transactions_ | — | — | — | — | — |`;
+
+    const filters = metadata.appliedFilters.length > 0 ? metadata.appliedFilters : ['None'];
+    const filtersList = filters.map((filter) => `- ${filter}`).join('\n');
+
+    return [
+      '# Filtered Transactions',
+      '',
+      `**Account reference provided:** ${metadata.accountReference}`,
+      `**Resolved account ID:** ${metadata.resolvedAccountId}`,
+      `**Date range evaluated:** ${metadata.dateRange.start} → ${metadata.dateRange.end}`,
+      `**Transactions returned:** ${metadata.filteredCount} of ${metadata.totalFetched} fetched`,
+      '',
+      '**Applied filters:**',
+      filtersList,
+      '',
+      table,
+    ].join('\n');
   }
 }

--- a/src/tools/monthly-summary/data-fetcher.ts
+++ b/src/tools/monthly-summary/data-fetcher.ts
@@ -2,6 +2,7 @@ import { fetchAllAccounts } from '../../core/data/fetch-accounts.js';
 import { fetchAllCategories } from '../../core/data/fetch-categories.js';
 import { fetchTransactionsForAccount, fetchAllOnBudgetTransactions } from '../../core/data/fetch-transactions.js';
 import type { Account, Category, Transaction } from '../../core/types/domain.js';
+import { resolveAccountSelection } from '../../core/utils/account-selector.js';
 
 export class MonthlySummaryDataFetcher {
   /**
@@ -20,9 +21,11 @@ export class MonthlySummaryDataFetcher {
     const accounts = await fetchAllAccounts();
     const categories = await fetchAllCategories();
 
+    const { accountId: resolvedAccountId } = await resolveAccountSelection(accounts, accountId);
+
     let transactions: Transaction[] = [];
-    if (accountId) {
-      transactions = await fetchTransactionsForAccount(accountId, start, end);
+    if (resolvedAccountId) {
+      transactions = await fetchTransactionsForAccount(resolvedAccountId, start, end, { accountIdIsResolved: true });
     } else {
       transactions = await fetchAllOnBudgetTransactions(accounts, start, end);
     }

--- a/src/tools/spending-by-category/data-fetcher.ts
+++ b/src/tools/spending-by-category/data-fetcher.ts
@@ -3,6 +3,7 @@ import { fetchAllAccounts } from '../../core/data/fetch-accounts.js';
 import { fetchAllCategories, fetchAllCategoryGroups } from '../../core/data/fetch-categories.js';
 import { fetchTransactionsForAccount, fetchAllOnBudgetTransactions } from '../../core/data/fetch-transactions.js';
 import type { Account, Category, CategoryGroup, Transaction } from '../../core/types/domain.js';
+import { resolveAccountSelection } from '../../core/utils/account-selector.js';
 
 export class SpendingByCategoryDataFetcher {
   /**
@@ -24,8 +25,10 @@ export class SpendingByCategoryDataFetcher {
     const categoryGroups = await fetchAllCategoryGroups();
 
     let transactions: Transaction[] = [];
-    if (accountId) {
-      transactions = await fetchTransactionsForAccount(accountId, start, end);
+    const { accountId: resolvedAccountId } = await resolveAccountSelection(accounts, accountId);
+
+    if (resolvedAccountId) {
+      transactions = await fetchTransactionsForAccount(resolvedAccountId, start, end, { accountIdIsResolved: true });
     } else {
       transactions = await fetchAllOnBudgetTransactions(accounts, start, end);
     }


### PR DESCRIPTION
### **User description**
## Summary
- resolve account references before fetching transactions and expose a helper for reusing the lookup
- update transaction-driven tools to support name-based account selection and enhance reporting metadata
- add unit coverage for the new account selection helper and name resolution behavior

## Testing
- npm run test -- src/core/data/fetch-transactions.test.ts src/core/utils/account-selector.test.ts

------
https://chatgpt.com/codex/tasks/task_e_690ce9d34fa8833394d2e997ed886548


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Resolve account names/IDs before fetching transactions using `nameResolver`

- Add `resolveAccountSelection` helper for reusable account reference resolution

- Update transaction-driven tools to support name-based account selection

- Enhance transaction report with detailed metadata and filter descriptions

- Extend test coverage for account resolution and name-based lookups

- Update default date range from 30 days to 3 months in documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Account Reference<br/>Name or ID"] -->|nameResolver.resolveAccount| B["Resolved Account ID"]
  B -->|accountIdIsResolved flag| C["fetchTransactionsForAccount"]
  C -->|enriched transactions| D["Transaction Report"]
  E["resolveAccountSelection<br/>Helper"] -->|reusable lookup| F["Tools<br/>get-transactions<br/>balance-history<br/>monthly-summary<br/>spending-by-category"]
  F -->|uses| C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>fetch-transactions.ts</strong><dd><code>Add account name resolution before transaction fetch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/10/files#diff-9b4d00e8bc40bd3d8c4f52d7a89126b09aef7f3a3207adf70fb8b1c605366fdd">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>account-selector.ts</strong><dd><code>Create reusable account selection resolver helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/10/files#diff-7bea18a7ae390e0e5f9d3c017cecc6515c45556024a5cc2d369db0064b2a3835">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.ts</strong><dd><code>Integrate account resolution and improve reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/10/files#diff-c2b1b095a3928987b191449c4ab2eb0187ecd5d4503d3e8f5331f345000ff720">+33/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>report-generator.ts</strong><dd><code>Enhance report with metadata and filter details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/10/files#diff-3a4eaf85d130cb117eb454fb2cd9c434efdc604008805e540d031a78c2cd8715">+40/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>data-fetcher.ts</strong><dd><code>Add options parameter for resolved account IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/10/files#diff-cc4614811f9e07427d91d40de60506233aea0b927496a78c3a508a45dc2322ba">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>data-fetcher.ts</strong><dd><code>Use account selector for name-based resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/10/files#diff-d246fc487fcb9091e0ad385e611869a7357ce0617ca8dc22a377108252a6f891">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>data-fetcher.ts</strong><dd><code>Integrate account selection resolver helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/10/files#diff-b9e259f6a9cfe450b7b32cfb1af102d9c37e257572cbe5432c83e77a0d11f74d">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>data-fetcher.ts</strong><dd><code>Integrate account selection resolver helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/10/files#diff-1cc7ce1422334309fa16b347abb3b56e6a2ae0ad255b2e8f7be0d2813e9f1734">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>fetch-transactions.test.ts</strong><dd><code>Add mocks and tests for account resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/10/files#diff-6f4066270a1264734094272c271973b590e33fa8f882bb63b4fb49cc30ef77fe">+22/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>account-selector.test.ts</strong><dd><code>Add unit tests for account selector helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/10/files#diff-6c9abe36a1e9c02d30e92b22233f706af7dfa637aeee55d3dfe18c4e1f504a6d">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>schemas.ts</strong><dd><code>Update default date range documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/10/files#diff-c6044ee445d38c4fc76691772a50aa8a8453c4fd97c8d015d6860fc1fc568da7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

