### PR TITLE
Fix transaction imports to stay uncleared and invalidate caches

### DIFF
--- a/src/actual-api.test.ts
+++ b/src/actual-api.test.ts
@@ -10,6 +10,7 @@ vi.mock('@actual-app/api', () => ({
     shutdown: vi.fn(),
     sync: vi.fn(),
     deleteTransaction: vi.fn(),
+    importTransactions: vi.fn(),
   },
 }));
 
@@ -396,6 +397,57 @@ describe('Auto-load functionality', () => {
       vi.mocked(api.deleteTransaction).mockRejectedValue(new Error('Transaction not found'));
 
       await expect(actualApi.deleteTransaction('invalid-id')).rejects.toThrow('Transaction not found');
+    });
+  });
+
+  describe('importTransactions', () => {
+    beforeEach(async () => {
+      process.env.ACTUAL_DATA_DIR = '/test/data';
+      vi.mocked(api.getBudgets).mockResolvedValue([
+        { id: 'budget-1', cloudFileId: 'test-budget', name: 'Test Budget' },
+      ]);
+      vi.mocked(api.init).mockResolvedValue(undefined);
+      vi.mocked(api.downloadBudget).mockResolvedValue(undefined);
+      vi.mocked(cacheService.invalidate).mockClear();
+      vi.mocked(api.importTransactions).mockResolvedValue({ added: ['txn-1'], updated: [] });
+    });
+
+    it('should import transactions and invalidate caches', async () => {
+      const result = await actualApi.importTransactions('account-123', [
+        {
+          date: '2024-01-10',
+          amount: -1234,
+          notes: 'Test',
+        },
+      ]);
+
+      expect(api.importTransactions).toHaveBeenCalledWith('account-123', [
+        expect.objectContaining({
+          account: 'account-123',
+          amount: -1234,
+          date: '2024-01-10',
+        }),
+      ]);
+      expect(cacheService.invalidate).toHaveBeenCalledWith('transactions');
+      expect(cacheService.invalidate).toHaveBeenCalledWith('accounts:all');
+      expect(result).toEqual({ added: ['txn-1'], updated: [] });
+    });
+
+    it('should throw when API reports errors', async () => {
+      vi.mocked(api.importTransactions).mockResolvedValue({
+        added: [],
+        updated: [],
+        errors: ['duplicate transaction'],
+      });
+
+      await expect(
+        actualApi.importTransactions('account-123', [
+          {
+            date: '2024-01-10',
+            amount: -1234,
+          },
+        ])
+      ).rejects.toThrow('importTransactions reported errors: duplicate transaction');
     });
   });
 });

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -439,7 +439,16 @@ export async function importTransactions(
       category: subtransaction.category ?? undefined,
     })),
   }));
-  return api.importTransactions(accountId, transactionsWithAccount);
+  const result = await api.importTransactions(accountId, transactionsWithAccount);
+
+  if (result.errors && result.errors.length > 0) {
+    throw new Error(`importTransactions reported errors: ${result.errors.join('; ')}`);
+  }
+
+  cacheService.invalidate('transactions');
+  cacheService.invalidate('accounts:all');
+
+  return result;
 }
 
 /**

--- a/src/tools/manage-transaction/data-fetcher.test.ts
+++ b/src/tools/manage-transaction/data-fetcher.test.ts
@@ -54,11 +54,13 @@ describe('ManageTransactionDataFetcher', () => {
   });
 
   describe('create operation', () => {
-    it('should create transaction successfully', async () => {
+    it('should create transaction successfully with uncleared default', async () => {
       vi.mocked(importTransactions).mockResolvedValue({
         added: ['new-txn-id'],
         updated: [],
       });
+
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1234567890);
 
       const result = await fetcher.execute({
         operation: 'create',
@@ -67,11 +69,35 @@ describe('ManageTransactionDataFetcher', () => {
         amount: -4599,
       });
 
-      expect(importTransactions).toHaveBeenCalled();
+      expect(importTransactions).toHaveBeenCalledWith('account-123', [
+        expect.objectContaining({
+          cleared: false,
+          imported_id: 'manual-account-123-2024-01-15--4599-1234567890',
+        }),
+      ]);
       expect(result).toEqual({
         transactionId: 'new-txn-id',
         operation: 'create',
       });
+
+      nowSpy.mockRestore();
+    });
+
+    it('should surface errors returned from importTransactions', async () => {
+      vi.mocked(importTransactions).mockResolvedValue({
+        added: [],
+        updated: [],
+        errors: ['duplicate transaction detected'],
+      });
+
+      await expect(
+        fetcher.execute({
+          operation: 'create',
+          accountId: 'account-123',
+          date: '2024-01-15',
+          amount: -4599,
+        })
+      ).rejects.toThrow('Failed to create transaction: duplicate transaction detected');
     });
 
     it('should throw error when accountId is missing for create', async () => {

--- a/src/tools/manage-transaction/data-fetcher.ts
+++ b/src/tools/manage-transaction/data-fetcher.ts
@@ -43,12 +43,16 @@ export class ManageTransactionDataFetcher {
       payee: input.payeeId || null,
       category: input.categoryId || null,
       notes: input.notes || '',
-      cleared: input.cleared ?? true,
+      cleared: input.cleared ?? false,
       imported_id: `manual-${input.accountId}-${input.date}-${input.amount ?? 0}-${Date.now()}`,
     };
 
     // Import the transaction (this will run rules, detect duplicates, etc.)
     const importResult = await importTransactions(input.accountId, [transaction]);
+
+    if (importResult.errors?.length) {
+      throw new Error(`Failed to create transaction: ${importResult.errors.join('; ')}`);
+    }
 
     // Get the transaction ID from the result
     const transactionId = importResult.added[0] || importResult.updated[0];


### PR DESCRIPTION
### **User description**
## Summary
- default manually created transactions to uncleared status and surface import errors for visibility
- invalidate transaction and account caches after imports and cover the behavior with targeted unit tests

## Testing
- npm run test *(fails: integration suites expect Actual sample data and report missing accounts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690cf72d0d3083339252cfa0300ec7ae


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Change manually created transactions default to uncleared status

- Add error handling to surface import errors and prevent silent failures

- Invalidate transaction and account caches after successful imports

- Add comprehensive unit tests for import behavior and error scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Transaction Import"] --> B["Set cleared: false"]
  A --> C["Check for errors"]
  C -->|Errors found| D["Throw error"]
  C -->|Success| E["Invalidate caches"]
  E --> F["Return result"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actual-api.ts</strong><dd><code>Add error handling and cache invalidation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/actual-api.ts

<ul><li>Changed <code>importTransactions</code> to await the API call and check for errors<br> <li> Added error throwing when API returns errors array<br> <li> Added cache invalidation for 'transactions' and 'accounts:all' after <br>successful import<br> <li> Improved error visibility by surfacing import errors to callers</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/11/files#diff-47df487a2e6df9af4f552ee17bc1c08d1054358ee61a3503d841938c192ea843">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>data-fetcher.ts</strong><dd><code>Default transactions to uncleared with error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/manage-transaction/data-fetcher.ts

<ul><li>Changed default <code>cleared</code> value from <code>true</code> to <code>false</code> for manually created <br>transactions<br> <li> Added error handling to check <code>importResult.errors</code> and throw <br>descriptive error<br> <li> Improved error messages to include specific import errors</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/11/files#diff-7e4292667fd8ea3985a3b668a0c294ca0d7c8081d8f7d49b0fb1a96a99bc40c7">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actual-api.test.ts</strong><dd><code>Add importTransactions mock and test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/actual-api.test.ts

<ul><li>Added <code>importTransactions</code> to the mocked API object<br> <li> Added new test suite for <code>importTransactions</code> with setup and teardown<br> <li> Added test for successful import with cache invalidation verification<br> <li> Added test for error handling when API reports errors</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/11/files#diff-66cd06e723bdb923807c8b508e3f91c65a9810cfeb0f4465ccd54bbbb486df79">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>data-fetcher.test.ts</strong><dd><code>Enhance tests for uncleared default and error handling</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tools/manage-transaction/data-fetcher.test.ts

<ul><li>Updated test name to reflect uncleared default behavior<br> <li> Added spy on <code>Date.now()</code> to verify unique <code>imported_id</code> generation<br> <li> Enhanced test to verify <code>cleared: false</code> and <code>imported_id</code> format<br> <li> Added new test to verify error surfacing from <code>importTransactions</code><br> <li> Improved test assertions with <code>expect.objectContaining()</code> for better <br>specificity</ul>


</details>


  </td>
  <td><a href="https://github.com/guitarbeat/actual-mcp/pull/11/files#diff-966645b79f2a2ba67357b103ca46ac7126b1f6d31eb4de5e7409d68278e91b3a">+28/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

