### PR TITLE
🎨 Palette: Add checkmark feedback to copy button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@
 ## 2026-01-25 - Accessible Status Feedback
 **Learning:** Visual-only tooltips for transient states (like "Copied!") are invisible to screen readers. Adding `role="status"` and `aria-live="polite"` makes these updates accessible without disrupting the user flow.
 **Action:** Ensure all temporary visual feedback elements include appropriate ARIA roles and live region attributes.
+
+## 2026-02-06 - Visual Confirmation for Actions
+**Learning:** For actions like "Copy to Clipboard", a tooltip is often insufficient for immediate visual confirmation. Swapping the icon (e.g., Copy -> Checkmark) provides an unmistakable, delightful confirmation that works well even without reading text.
+**Action:** Implement icon state swaps for binary actions (copy, save, like) to provide strong visual feedback, ensuring accessible text/tooltips remain for screen readers.

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -404,7 +404,8 @@ async function main(): Promise<void> {
           <span class="path" style="flex: 0 0 auto">${path}</span>
           <div class="tooltip-container">
             <button class="copy-btn" data-path="${path}" aria-label="Copy ${path} URL">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+              <svg class="icon-copy" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+              <svg class="icon-check" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
             </button>
             <span class="tooltip-text" role="status" aria-live="polite">Copied!</span>
           </div>
@@ -551,6 +552,10 @@ async function main(): Promise<void> {
               .copy-btn.copied {
                 color: var(--success);
               }
+              .copy-btn .icon-check { display: none; }
+              .copy-btn.copied .icon-copy { display: none; }
+              .copy-btn.copied .icon-check { display: block; }
+
               .tooltip-container {
                 position: relative;
                 display: inline-flex;


### PR DESCRIPTION
💡 What: Updated the dashboard copy-to-clipboard button to swap the clipboard icon with a checkmark icon upon successful copy.
🎯 Why: Provides immediate, unmistakable visual confirmation of success, enhancing the user experience ("delight").
📸 Before/After: The button now shows a checkmark for 2 seconds after clicking.
♿ Accessibility: The existing `aria-label` and `aria-live` tooltip are preserved for screen reader users. The icon change is a progressive enhancement for sighted users.

---
*PR created automatically by Jules for task [17855981633932890633](https://jules.google.com/task/17855981633932890633) started by @guitarbeat*