### PR TITLE
🎨 Palette: Fix tooltip clipping and improve copy button accessibility

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -423,8 +423,8 @@ async function main(): Promise<void> {
           <span class="path" style="flex: 0 0 auto">${path}</span>
           <div class="tooltip-container">
             <button class="copy-btn" data-path="${path}" aria-label="Copy ${path} URL">
-              <svg class="icon-copy" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
-              <svg class="icon-check" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+              <svg class="icon-copy" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+              <svg class="icon-check" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
             </button>
             <span class="tooltip-text" role="status" aria-live="polite">Copied!</span>
           </div>
@@ -528,7 +528,7 @@ async function main(): Promise<void> {
               }
               .label { font-size: 11px; text-transform: uppercase; color: var(--muted); display: block; margin-bottom: 4px; }
               .val { font-size: 14px; font-weight: 500; }
-              .endpoints { border: 1px solid var(--border); border-radius: 6px; overflow: hidden; list-style: none; padding: 0; margin: 0; }
+              .endpoints { border: 1px solid var(--border); border-radius: 6px; list-style: none; padding: 0; margin: 0; }
               .ep-row {
                 padding: 8px 12px;
                 display: flex;
@@ -556,7 +556,7 @@ async function main(): Promise<void> {
                 background: none;
                 border: none;
                 cursor: pointer;
-                padding: 4px;
+                padding: 6px;
                 color: var(--muted);
                 border-radius: 4px;
                 display: inline-flex;


### PR DESCRIPTION
- **What:** Removed `overflow: hidden` from `.endpoints` container and increased `.copy-btn` padding. Added `aria-hidden="true"` and `focusable="false"` to decorative SVGs.
- **Why:** The "Copied!" tooltip was being clipped on the first item in the list. The copy buttons were a bit small for touch targets. The SVGs were not properly hidden from screen readers.
- **Accessibility:** Improved screen reader experience by hiding decorative icons and ensuring tooltips are visible. Improved touch target size.
- **Verification:** Verified visually with Playwright screenshot and ran lint/type-check/tests.


---
*PR created automatically by Jules for task [14740037109063554388](https://jules.google.com/task/14740037109063554388) started by @guitarbeat*