### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in dashboard rendering

### DIFF
--- a/mcp-server/src/core/utils/dashboard.test.ts
+++ b/mcp-server/src/core/utils/dashboard.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { renderEndpoint, renderStat } from './dashboard.js';
+
+describe('dashboard utils', () => {
+  describe('renderStat', () => {
+    it('should escape HTML in label and value', () => {
+      const result = renderStat('<script>', '&"');
+      expect(result).toContain('&lt;script&gt;');
+      expect(result).toContain('&amp;&quot;');
+    });
+
+    it('should render correctly with safe values', () => {
+      const result = renderStat('Label', 'Value');
+      expect(result).toContain('<dt class="label">Label</dt>');
+      expect(result).toContain('<dd class="val">Value</dd>');
+    });
+  });
+
+  describe('renderEndpoint', () => {
+    it('should escape HTML in all fields', () => {
+      const method = '<script>';
+      const color = 'primary" style="bad';
+      const path = '/path" onclick="alert(1)';
+      const desc = '<b>bold</b>';
+
+      const result = renderEndpoint(method, color, path, desc);
+
+      // Method escaping
+      expect(result).toContain('&lt;script&gt;');
+
+      // Color escaping (prevents breaking out of style attribute or var())
+      expect(result).toContain('var(--primary&quot; style=&quot;bad)');
+
+      // Path escaping (prevents breaking out of data-path attribute)
+      expect(result).toContain('data-path="/path&quot; onclick=&quot;alert(1)"');
+      expect(result).toContain('aria-label="Copy /path&quot; onclick=&quot;alert(1) URL"');
+
+      // Description escaping
+      expect(result).toContain('&lt;b&gt;bold&lt;/b&gt;');
+    });
+
+    it('should render correctly with safe values', () => {
+      const result = renderEndpoint('GET', 'success', '/api', 'Description');
+      expect(result).toContain('<span class="method" style="color: var(--success)">GET</span>');
+      expect(result).toContain('<span class="path" style="flex: 0 0 auto">/api</span>');
+      expect(result).toContain('data-path="/api"');
+      expect(result).toContain('<span class="desc">Description</span>');
+    });
+  });
+});

--- a/mcp-server/src/core/utils/dashboard.ts
+++ b/mcp-server/src/core/utils/dashboard.ts
@@ -1,0 +1,24 @@
+import { escapeHtml } from './html-utils.js';
+
+export const renderStat = (label: string, value: string | number) => `
+  <div class="item">
+    <dt class="label">${escapeHtml(label)}</dt>
+    <dd class="val">${escapeHtml(value)}</dd>
+  </div>
+`;
+
+export const renderEndpoint = (method: string, color: string, path: string, desc: string) => `
+  <li class="ep-row">
+    <span class="method" style="color: var(--${escapeHtml(color)})">${escapeHtml(method)}</span>
+    <span class="path" style="flex: 0 0 auto">${escapeHtml(path)}</span>
+    <div class="tooltip-container">
+      <button class="copy-btn" data-path="${escapeHtml(path)}" aria-label="Copy ${escapeHtml(path)} URL">
+        <svg class="icon-copy" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+        <svg class="icon-check" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+      </button>
+      <span class="tooltip-text" role="status" aria-live="polite">Copied!</span>
+    </div>
+    <div style="flex: 1"></div>
+    <span class="desc">${escapeHtml(desc)}</span>
+  </li>
+`;

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -34,7 +34,7 @@ import { restoreConsoleMethods, setupSafeLogging } from './core/logging/safe-log
 import { corsMiddleware } from './core/transport/cors.js';
 import { securityHeaders } from './core/transport/security-headers.js';
 import { StreamableHTTPHandler } from './core/transport/streamable-http-handler.js';
-import { escapeHtml } from './core/utils/html-utils.js';
+import { renderEndpoint, renderStat } from './core/utils/dashboard.js';
 import { setupPrompts } from './prompts.js';
 import { setupResources } from './resources.js';
 import { setupTools } from './tools/index.js';
@@ -415,29 +415,6 @@ async function main(): Promise<void> {
       };
 
       const { type: statusType, text: statusText } = getStatusDetails();
-
-      const renderStat = (label: string, value: string | number) => `
-        <div class="item">
-          <dt class="label">${escapeHtml(label)}</dt>
-          <dd class="val">${escapeHtml(value)}</dd>
-        </div>
-      `;
-
-      const renderEndpoint = (method: string, color: string, path: string, desc: string) => `
-        <li class="ep-row">
-          <span class="method" style="color: var(--${color})">${method}</span>
-          <span class="path" style="flex: 0 0 auto">${path}</span>
-          <div class="tooltip-container">
-            <button class="copy-btn" data-path="${path}" aria-label="Copy ${path} URL">
-              <svg class="icon-copy" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
-              <svg class="icon-check" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
-            </button>
-            <span class="tooltip-text" role="status" aria-live="polite">Copied!</span>
-          </div>
-          <div style="flex: 1"></div>
-          <span class="desc">${desc}</span>
-        </li>
-      `;
 
       return `
         <!DOCTYPE html>


### PR DESCRIPTION
This PR addresses a potential XSS vulnerability in the MCP server dashboard.
Previously, the `renderEndpoint` function in `src/index.ts` interpolated values (method, color, path, description) directly into the HTML string without escaping. While these values were currently hardcoded, any future dynamic usage could have led to XSS.

Changes:
- Extracted `renderStat` and `renderEndpoint` to `mcp-server/src/core/utils/dashboard.ts`.
- Applied `escapeHtml` to all inputs in `renderEndpoint`.
- Added `mcp-server/src/core/utils/dashboard.test.ts` to verify correct escaping.
- Updated `mcp-server/src/index.ts` to import the secured functions.
- Verified that all tests pass.

---
*PR created automatically by Jules for task [4556246717017772804](https://jules.google.com/task/4556246717017772804) started by @guitarbeat*