### PR TITLE
⚡ Bolt: Optimize group-by sorting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@ This journal records critical performance learnings, anti-patterns, and architec
 ## 2026-02-08 - [Object Iteration vs Array Allocation]
 **Learning:** When aggregating data from a large object (Record), using `for...in` loop is significantly faster (~15%) than `Object.values()` or `Object.entries()` because it avoids allocating an intermediate array of keys or values.
 **Action:** For performance-critical loops over large objects, prefer `for...in` combined with incremental processing (e.g. summing) to minimize allocations and passes.
+
+## 2026-02-27 - [Sort Allocation Overhead]
+**Learning:** `sortBy` utility, while convenient, creates a shallow copy of the array and has function call overhead. For performance-critical paths where the array is locally owned (e.g., constructed within the function), in-place `Array.prototype.sort` is faster and avoids unnecessary allocations.
+**Action:** When sorting locally constructed arrays in hot paths, prefer direct `Array.prototype.sort` over utility functions that copy.

--- a/mcp-server/src/core/aggregation/group-by.ts
+++ b/mcp-server/src/core/aggregation/group-by.ts
@@ -1,6 +1,5 @@
 // Aggregates category spendings into groups and sorts them
 import type { CategorySpending, GroupSpending } from '../types/domain.js';
-import { sortBy } from './sort-by.js';
 
 /**
  * Aggregates category spending data into groups and sorts by total spending.
@@ -24,7 +23,7 @@ export class GroupAggregator {
 
     // Direct iteration over record keys to avoid Object.values/Object.entries array allocation
     for (const key in spendingByCategory) {
-      if (Object.prototype.hasOwnProperty.call(spendingByCategory, key)) {
+      if (Object.hasOwn(spendingByCategory, key)) {
         const category = spendingByCategory[key];
         const groupName = category.group;
         let group = groupsMap.get(groupName);
@@ -43,18 +42,21 @@ export class GroupAggregator {
     const groups: GroupSpending[] = [];
 
     for (const [groupName, { total, categories }] of groupsMap) {
-      // Sort categories within the group
-      const sortedCategories = sortBy(categories, [(cat) => Math.abs(cat.total)], ['desc']);
+      // Optimization: Sort categories within the group in-place to avoid array allocation
+      // Performance: Faster than sortBy because it avoids creating a new array and function call overhead
+      categories.sort((a, b) => (Math.abs(b.total) || 0) - (Math.abs(a.total) || 0));
 
       groups.push({
         name: groupName,
         total,
-        categories: sortedCategories,
+        categories,
       });
     }
 
-    // Sort groups by absolute total (descending)
-    return sortBy(groups, [(group) => Math.abs(group.total)], ['desc']);
+    // Optimization: Sort groups by absolute total (descending) in-place
+    groups.sort((a, b) => (Math.abs(b.total) || 0) - (Math.abs(a.total) || 0));
+
+    return groups;
   }
 
   /**


### PR DESCRIPTION
⚡ Bolt: Optimized group-by sorting

💡 What: Replaced `sortBy` utility with in-place `Array.prototype.sort` in `GroupAggregator.aggregateAndSort`.
🎯 Why: `sortBy` creates a shallow copy of the array and has function call overhead. Since the arrays in `aggregateAndSort` are locally constructed, we can sort them in-place safely to save memory and CPU.
📊 Impact: Reduces array allocations and improves sorting performance.
🔬 Measurement: Verified with existing unit tests (`src/core/aggregation/group-by.test.ts`).

---
*PR created automatically by Jules for task [5097807632796077862](https://jules.google.com/task/5097807632796077862) started by @guitarbeat*