### PR TITLE
Optimize transaction fetching with cached lookup maps

### DIFF
--- a/mcp-server/pnpm-lock.yaml
+++ b/mcp-server/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@actual-app/api':
-        specifier: ^25.12.0
-        version: 25.12.0
+        specifier: ^26.2.0
+        version: 26.2.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.1
         version: 1.26.0(zod@3.25.76)
@@ -24,19 +24,19 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       dotenv:
-        specifier: ^16.4.7
-        version: 16.6.1
+        specifier: ^17.2.4
+        version: 17.2.4
       express:
         specifier: ^5.2.1
         version: 5.2.1
       lru-cache:
-        specifier: ^10.4.3
-        version: 10.4.3
+        specifier: ^11.2.5
+        version: 11.2.5
       openai:
-        specifier: ^6.15.0
+        specifier: ^6.18.0
         version: 6.18.0(zod@3.25.76)
       zod:
-        specifier: ^3.23.11
+        specifier: ^3.25.76
         version: 3.25.76
       zod-to-json-schema:
         specifier: ^3.25.1
@@ -96,8 +96,8 @@ importers:
 
 packages:
 
-  '@actual-app/api@25.12.0':
-    resolution: {integrity: sha512-W9xFQtHdEehEX7V6qKmOsaToK/Vj/Y/J11IHGKtowma5olhBF2qCCJcB6AKaHBmIZ6A3lkVd+WFkNfP5I/hREA==}
+  '@actual-app/api@26.2.0':
+    resolution: {integrity: sha512-Or0694ALXY950jy1A92Wrwqz2qItigsLMtKJgwl7eL16de3sDKw5yOZGEq2W561i16mQqdYTT+810N+y2QXbpA==}
     engines: {node: '>=20'}
 
   '@actual-app/crdt@2.1.0':
@@ -1321,6 +1321,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.2.5:
+    resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1990,7 +1994,7 @@ packages:
 
 snapshots:
 
-  '@actual-app/api@25.12.0':
+  '@actual-app/api@26.2.0':
     dependencies:
       '@actual-app/crdt': 2.1.0
       better-sqlite3: 12.6.2
@@ -3217,6 +3221,8 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.2.5: {}
 
   magic-string@0.30.21:
     dependencies:

--- a/mcp-server/src/core/api/actual-client.ts
+++ b/mcp-server/src/core/api/actual-client.ts
@@ -554,7 +554,7 @@ export async function createPayee(args: Record<string, unknown>): Promise<string
       throw new Error('Payee name is required');
     }
     const result = await api.createPayee(args as Omit<APIPayeeEntity, 'id'>);
-    cacheService.invalidate('payees:all');
+    cacheService.invalidatePattern('payees:*');
     return result;
   });
 }
@@ -565,7 +565,7 @@ export async function createPayee(args: Record<string, unknown>): Promise<string
 export async function updatePayee(id: string, args: Record<string, unknown>): Promise<unknown> {
   return ensureConnection(async () => {
     const result = await api.updatePayee(id, args);
-    cacheService.invalidate('payees:all');
+    cacheService.invalidatePattern('payees:*');
     return result;
   });
 }
@@ -576,7 +576,7 @@ export async function updatePayee(id: string, args: Record<string, unknown>): Pr
 export async function deletePayee(id: string): Promise<unknown> {
   return ensureConnection(async () => {
     const result = await api.deletePayee(id);
-    cacheService.invalidate('payees:all');
+    cacheService.invalidatePattern('payees:*');
     return result;
   });
 }
@@ -608,7 +608,7 @@ export async function deleteRule(id: string): Promise<boolean> {
 export async function createCategory(args: Record<string, unknown>): Promise<string> {
   return ensureConnection(async () => {
     const result = await api.createCategory(args as Omit<APICategoryEntity, 'id'>);
-    cacheService.invalidate('categories:all');
+    cacheService.invalidatePattern('categories:*');
     return result;
   });
 }
@@ -619,7 +619,7 @@ export async function createCategory(args: Record<string, unknown>): Promise<str
 export async function updateCategory(id: string, args: Record<string, unknown>): Promise<unknown> {
   return ensureConnection(async () => {
     const result = await api.updateCategory(id, args);
-    cacheService.invalidate('categories:all');
+    cacheService.invalidatePattern('categories:*');
     return result;
   });
 }
@@ -630,7 +630,7 @@ export async function updateCategory(id: string, args: Record<string, unknown>):
 export async function deleteCategory(id: string): Promise<{ error?: string }> {
   return ensureConnection(async () => {
     const result = await api.deleteCategory(id);
-    cacheService.invalidate('categories:all');
+    cacheService.invalidatePattern('categories:*');
     return result;
   });
 }
@@ -641,7 +641,7 @@ export async function deleteCategory(id: string): Promise<{ error?: string }> {
 export async function createCategoryGroup(args: Record<string, unknown>): Promise<string> {
   return ensureConnection(async () => {
     const result = await api.createCategoryGroup(args as Omit<APICategoryGroupEntity, 'id'>);
-    cacheService.invalidate('categoryGroups:all');
+    cacheService.invalidatePattern('categoryGroups:*');
     return result;
   });
 }
@@ -652,7 +652,7 @@ export async function createCategoryGroup(args: Record<string, unknown>): Promis
 export async function updateCategoryGroup(id: string, args: Record<string, unknown>): Promise<unknown> {
   return ensureConnection(async () => {
     const result = await api.updateCategoryGroup(id, args);
-    cacheService.invalidate('categoryGroups:all');
+    cacheService.invalidatePattern('categoryGroups:*');
     return result;
   });
 }
@@ -663,7 +663,7 @@ export async function updateCategoryGroup(id: string, args: Record<string, unkno
 export async function deleteCategoryGroup(id: string): Promise<unknown> {
   return ensureConnection(async () => {
     const result = await api.deleteCategoryGroup(id);
-    cacheService.invalidate('categoryGroups:all');
+    cacheService.invalidatePattern('categoryGroups:*');
     return result;
   });
 }
@@ -940,7 +940,7 @@ export async function getSchedules(): Promise<unknown[]> {
 export async function mergePayees(targetId: string, sourceIds: string[]): Promise<unknown> {
   return ensureConnection(async () => {
     const result = await api.mergePayees(targetId, sourceIds);
-    cacheService.invalidate('payees:all');
+    cacheService.invalidatePattern('payees:*');
     return result;
   });
 }

--- a/mcp-server/src/core/cache/cache-service.ts
+++ b/mcp-server/src/core/cache/cache-service.ts
@@ -61,7 +61,7 @@ export class CacheService {
     }
 
     const cached = this.get<T>(key);
-    if (cached !== null) {
+    if (cached !== undefined) {
       this.hits++;
       return cached;
     }
@@ -91,11 +91,10 @@ export class CacheService {
    * Get data from cache if exists and not expired.
    *
    * @param key - Cache key
-   * @returns Cached data or null if not found/expired
+   * @returns Cached data or undefined if not found/expired
    */
-  private get<T>(key: string): T | null {
-    const value = this.cache.get(key) as T | undefined;
-    return value ?? null;
+  private get<T>(key: string): T | undefined {
+    return this.cache.get(key) as T | undefined;
   }
 
   /**

--- a/mcp-server/src/core/data/fetch-categories.ts
+++ b/mcp-server/src/core/data/fetch-categories.ts
@@ -1,4 +1,6 @@
 import { getCategories, getCategoryGroups } from '../../core/api/actual-client.js';
+import { GroupAggregator } from '../aggregation/group-by.js';
+import { cacheService } from '../cache/cache-service.js';
 import type { Category, CategoryGroup } from '../types/domain.js';
 
 /**
@@ -12,6 +14,19 @@ export async function fetchAllCategories(): Promise<Category[]> {
 }
 
 /**
+ * Fetch all categories as a map keyed by ID, with caching support.
+ * Useful for lookups.
+ *
+ * @returns Record mapping category IDs to Category objects
+ */
+export async function fetchAllCategoriesMap(): Promise<Record<string, Category>> {
+  return cacheService.getOrFetch('categories:map', async () => {
+    const categories = await fetchAllCategories();
+    return new GroupAggregator().byId(categories);
+  });
+}
+
+/**
  * Fetch all category groups with caching support.
  * Results are cached for 5 minutes to improve performance.
  *
@@ -19,4 +34,17 @@ export async function fetchAllCategories(): Promise<Category[]> {
  */
 export async function fetchAllCategoryGroups(): Promise<CategoryGroup[]> {
   return getCategoryGroups();
+}
+
+/**
+ * Fetch all category groups as a map keyed by ID, with caching support.
+ * Useful for lookups.
+ *
+ * @returns Record mapping category group IDs to CategoryGroup objects
+ */
+export async function fetchAllCategoryGroupsMap(): Promise<Record<string, CategoryGroup>> {
+  return cacheService.getOrFetch('categoryGroups:map', async () => {
+    const groups = await fetchAllCategoryGroups();
+    return new GroupAggregator().byId(groups);
+  });
 }

--- a/mcp-server/src/core/data/fetch-payees.ts
+++ b/mcp-server/src/core/data/fetch-payees.ts
@@ -1,4 +1,6 @@
 import { getPayees } from '../../core/api/actual-client.js';
+import { GroupAggregator } from '../aggregation/group-by.js';
+import { cacheService } from '../cache/cache-service.js';
 import type { Payee } from '../types/domain.js';
 
 /**
@@ -9,4 +11,17 @@ import type { Payee } from '../types/domain.js';
  */
 export async function fetchAllPayees(): Promise<Payee[]> {
   return getPayees();
+}
+
+/**
+ * Fetch all payees as a map keyed by ID, with caching support.
+ * Useful for lookups.
+ *
+ * @returns Record mapping payee IDs to Payee objects
+ */
+export async function fetchAllPayeesMap(): Promise<Record<string, Payee>> {
+  return cacheService.getOrFetch('payees:map', async () => {
+    const payees = await fetchAllPayees();
+    return new GroupAggregator().byId(payees);
+  });
 }

--- a/mcp-server/src/core/data/fetch-transactions.ts
+++ b/mcp-server/src/core/data/fetch-transactions.ts
@@ -1,12 +1,9 @@
 import type { TransactionEntity } from '@actual-app/api/@types/loot-core/src/types/models/transaction.js';
 import { getTransactions } from '../../core/api/actual-client.js';
-import { GroupAggregator } from '../aggregation/group-by.js';
 import type { Account, Category, Payee, Transaction } from '../types/domain.js';
 import { nameResolver } from '../utils/name-resolver.js';
-import { fetchAllCategories } from './fetch-categories.js';
-import { fetchAllPayees } from './fetch-payees.js';
-
-const groupAggregator = new GroupAggregator();
+import { fetchAllCategoriesMap } from './fetch-categories.js';
+import { fetchAllPayeesMap } from './fetch-payees.js';
 
 interface TransactionLookupOptions {
   includePayees: boolean;
@@ -19,13 +16,12 @@ export interface TransactionLookups {
 }
 
 async function _buildTransactionLookups(options: TransactionLookupOptions): Promise<TransactionLookups> {
-  const [payees, categories] = await Promise.all([
-    options.includePayees ? fetchAllPayees() : Promise.resolve<Payee[]>([]),
-    options.includeCategories ? fetchAllCategories() : Promise.resolve<Category[]>([]),
+  // Optimization: Use cached maps to avoid rebuilding them on every call
+  // This reduces CPU usage and memory allocations when enriching large batches of transactions
+  const [payeesById, categoriesById] = await Promise.all([
+    options.includePayees ? fetchAllPayeesMap() : Promise.resolve<Record<string, Payee>>({}),
+    options.includeCategories ? fetchAllCategoriesMap() : Promise.resolve<Record<string, Category>>({}),
   ]);
-
-  const payeesById: Record<string, Payee> = options.includePayees ? groupAggregator.byId(payees) : {};
-  const categoriesById: Record<string, Category> = options.includeCategories ? groupAggregator.byId(categories) : {};
 
   return { payeesById, categoriesById };
 }


### PR DESCRIPTION
This PR optimizes the performance of transaction fetching and enrichment by caching the payee and category lookup maps. Previously, these maps were rebuilt from the full list of payees/categories for every transaction batch, which is inefficient for large datasets.

Changes:
1.  **CacheService Optimization**: Updated `getOrFetch` to distinguish between `undefined` (cache miss) and `null` (valid cached value). This prevents re-fetching when the cached value is `null`.
2.  **Cached Maps**: Added `fetchAllPayeesMap`, `fetchAllCategoriesMap`, and `fetchAllCategoryGroupsMap` in `src/core/data/`. these functions use `CacheService` to cache the `Record<string, Entity>` map.
3.  **Efficient Enrichment**: Updated `fetch-transactions.ts` to use these cached maps instead of fetching lists and rebuilding maps manually.
4.  **Robust Invalidation**: Updated `actual-client.ts` to use `cacheService.invalidatePattern('prefix:*')` (e.g., `payees:*`) instead of specific keys (e.g., `payees:all`). This ensures that both the list cache (`payees:all`) and the map cache (`payees:map`) are invalidated when an entity is created, updated, or deleted.

These changes should significantly reduce CPU usage and memory allocations for operations involving large numbers of transactions, payees, or categories.

---
*PR created automatically by Jules for task [14253778270636144564](https://jules.google.com/task/14253778270636144564) started by @guitarbeat*