### PR TITLE
⚡ Bolt: Use in-place sort in GroupAggregator

### DIFF
--- a/mcp-server/src/core/aggregation/group-by.ts
+++ b/mcp-server/src/core/aggregation/group-by.ts
@@ -1,6 +1,5 @@
 // Aggregates category spendings into groups and sorts them
 import type { CategorySpending, GroupSpending } from '../types/domain.js';
-import { sortBy } from './sort-by.js';
 
 /**
  * Aggregates category spending data into groups and sorts by total spending.
@@ -44,17 +43,20 @@ export class GroupAggregator {
 
     for (const [groupName, { total, categories }] of groupsMap) {
       // Sort categories within the group
-      const sortedCategories = sortBy(categories, [(cat) => Math.abs(cat.total)], ['desc']);
+      // Optimization: Sort in-place to avoid allocating new array
+      categories.sort((a, b) => Math.abs(b.total) - Math.abs(a.total));
 
       groups.push({
         name: groupName,
         total,
-        categories: sortedCategories,
+        categories,
       });
     }
 
     // Sort groups by absolute total (descending)
-    return sortBy(groups, [(group) => Math.abs(group.total)], ['desc']);
+    // Optimization: Sort in-place to avoid allocating new array
+    groups.sort((a, b) => Math.abs(b.total) - Math.abs(a.total));
+    return groups;
   }
 
   /**


### PR DESCRIPTION
💡 What: Replaced the `sortBy` utility function with native `Array.prototype.sort` in `mcp-server/src/core/aggregation/group-by.ts`.
🎯 Why: The `sortBy` utility creates a copy of the array (`[...array].sort()`) to ensure immutability. However, in `GroupAggregator`, the arrays are locally constructed and not shared, so in-place sorting is safe and more efficient.
📊 Impact: Reduces memory allocation by avoiding intermediate array copies for every group and the final result list. This is particularly beneficial when processing large numbers of categories.
🔬 Measurement: Verified with existing unit tests `pnpm run test:unit src/core/aggregation/group-by.test.ts`.

---
*PR created automatically by Jules for task [2041080661621021504](https://jules.google.com/task/2041080661621021504) started by @guitarbeat*