### PR TITLE
🎨 Palette: Enhance dashboard UX with Host stat and larger icons

### DIFF
--- a/mcp-server/src/core/utils/dashboard.ts
+++ b/mcp-server/src/core/utils/dashboard.ts
@@ -13,8 +13,8 @@ export const renderEndpoint = (method: string, color: string, path: string, desc
     <span class="path" style="flex: 0 0 auto">${escapeHtml(path)}</span>
     <div class="tooltip-container">
       <button class="copy-btn" data-path="${escapeHtml(path)}" aria-label="Copy ${escapeHtml(path)} URL">
-        <svg class="icon-copy" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
-        <svg class="icon-check" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+        <svg class="icon-copy" aria-hidden="true" focusable="false" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+        <svg class="icon-check" aria-hidden="true" focusable="false" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
       </button>
       <span class="tooltip-text" role="status" aria-live="polite">Copied!</span>
     </div>

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -631,6 +631,7 @@ async function main(): Promise<void> {
 
                 <dl class="grid">
                   ${renderStat('Port', resolvedPort)}
+                  ${renderStat('Host', bindHost)}
                   ${renderStat('Auth', enableBearer ? 'Enabled' : 'Disabled')}
                   ${renderStat('Init Time', stats.initializationTime ? `${stats.initializationTime}ms` : '---')}
                   ${renderStat('Sessions', streamableHandler.getActiveSessionCount())}


### PR DESCRIPTION
This PR improves the server-rendered dashboard UX by:
1.  **Adding a "Host" statistic:** This helps users immediately identify if the server is bound to `localhost` (127.0.0.1) or all interfaces (0.0.0.0), which is critical for debugging remote access.
2.  **Increasing icon size:** The copy-to-clipboard icons were increased from 12px to 14px to make them more visible and easier to interact with.

**Verification:**
- Verified via `pnpm run test` (all tests passed).
- Verified visually using a Playwright script and screenshot (confirmed Host stat appears and layout is correct).
- Verified build via `pnpm run build`.

---
*PR created automatically by Jules for task [271473330638538944](https://jules.google.com/task/271473330638538944) started by @guitarbeat*