### PR TITLE
Resolve merge conflicts in PR #152 (actual-mcp conflict resolution)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,6 +10,10 @@ This journal records critical performance learnings, anti-patterns, and architec
 **Learning:** `ensureConnection` was proactively checking connection health (via `api.getAccounts`) on *every* request, even when `cacheService` was hit. This doubled the latency for cached reads and negated some benefits of caching.
 **Action:** Trust the `initialized` state for the happy path ("Optimistic UI" pattern applied to backend). Only check health proactively if not initialized. Rely on error handling to detect and recover from dropped connections.
 
+## 2026-01-15 - [Aggregation Optimization]
+**Learning:** Generic `groupBy` + `sumBy` + `sortBy` pipelines incur significant overhead due to multiple iterations and closure allocations. In hot paths, single-pass aggregation using plain Objects (faster than Maps for string keys in this runtime) and native `sort` yielded ~24% improvement.
+**Action:** Prefer single-pass aggregation loops and native `Array.prototype.sort` over composing generic utility functions for high-frequency data processing.
+
 ## 2026-01-25 - [Promise.all Concurrency]
 **Learning:** Using `await` inside a `Promise.all` array element (e.g., `[await task1(), task2()]`) blocks the construction of the array and prevents `task2` from starting until `task1` completes, defeating the purpose of parallelism.
 **Action:** Always start promises *before* `Promise.all` or pass the promise itself (e.g., `[task1Promise, task2Promise]`) without `await`ing it inside the array literal.

--- a/mcp-server/src/core/aggregation/group-by.ts
+++ b/mcp-server/src/core/aggregation/group-by.ts
@@ -1,6 +1,5 @@
 // Aggregates category spendings into groups and sorts them
 import type { CategorySpending, GroupSpending } from '../types/domain.js';
-import { sortBy } from './sort-by.js';
 
 /**
  * Aggregates category spending data into groups and sorts by total spending.
@@ -44,17 +43,18 @@ export class GroupAggregator {
 
     for (const [groupName, { total, categories }] of groupsMap) {
       // Sort categories within the group
-      const sortedCategories = sortBy(categories, [(cat) => Math.abs(cat.total)], ['desc']);
+      // Optimization: Use native sort directly to avoid overhead of generic sortBy utility
+      categories.sort((a, b) => Math.abs(b.total) - Math.abs(a.total));
 
       groups.push({
         name: groupName,
         total,
-        categories: sortedCategories,
+        categories: categories,
       });
     }
 
     // Sort groups by absolute total (descending)
-    return sortBy(groups, [(group) => Math.abs(group.total)], ['desc']);
+    return groups.sort((a, b) => Math.abs(b.total) - Math.abs(a.total));
   }
 
   /**


### PR DESCRIPTION
Resolved merge conflicts between `HEAD` and `main` in PR #152. 
The conflict resolution strategy was:
1.  **Group Aggregation Optimization**: Combined the `Map`-based single-pass grouping from `main` (efficient iteration) with the in-place `Array.prototype.sort` from `HEAD` (avoiding intermediate array allocations). This implements the learnings from both branches.
2.  **Documentation**: Merged `.jules/bolt.md` to include performance learnings from both branches chronologically.
3.  **Baseline**: Accepted `main` version for all other files to incorporate recent security fixes (e.g., DNS rebinding protection, safe logging) and feature updates (e.g., dashboard improvements, dependency updates).

Verified the resolution by running the full unit test suite in `mcp-server`.

---
*PR created automatically by Jules for task [12650377986632395414](https://jules.google.com/task/12650377986632395414) started by @guitarbeat*