### PR TITLE
⚡ Bolt: Parallelize account balance fetching in get-accounts tool

### DIFF
--- a/mcp-server/src/tools/get-accounts/data-fetcher.test.ts
+++ b/mcp-server/src/tools/get-accounts/data-fetcher.test.ts
@@ -1,0 +1,88 @@
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetAccountsDataFetcher } from './data-fetcher.js';
+
+// Mock dependencies
+const mockFetchAllAccounts = vi.fn();
+const mockGetAccountBalance = vi.fn();
+
+vi.mock('../../core/data/fetch-accounts.js', () => ({
+  fetchAllAccounts: () => mockFetchAllAccounts(),
+}));
+
+vi.mock('../../core/api/actual-client.js', () => ({
+  getAccountBalance: (id: string) => mockGetAccountBalance(id),
+}));
+
+vi.mock('../../core/utils/name-resolver.js', () => ({
+  nameResolver: {
+    resolveAccount: vi.fn(),
+  },
+}));
+
+describe('GetAccountsDataFetcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches accounts and assigns balances correctly', async () => {
+    const accounts = [
+      { id: 'acc-1', name: 'Account 1', closed: false },
+      { id: 'acc-2', name: 'Account 2', closed: false },
+    ];
+
+    mockFetchAllAccounts.mockResolvedValue(accounts);
+    mockGetAccountBalance.mockImplementation(async (id) => {
+      if (id === 'acc-1') return 1000;
+      if (id === 'acc-2') return 2000;
+      return 0;
+    });
+
+    const fetcher = new GetAccountsDataFetcher();
+    const result = await fetcher.fetchAccounts({ includeClosed: false });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('acc-1');
+    expect(result[0].balance).toBe(1000);
+    expect(result[1].id).toBe('acc-2');
+    expect(result[1].balance).toBe(2000);
+
+    expect(mockGetAccountBalance).toHaveBeenCalledTimes(2);
+    expect(mockGetAccountBalance).toHaveBeenCalledWith('acc-1');
+    expect(mockGetAccountBalance).toHaveBeenCalledWith('acc-2');
+  });
+
+  it('filters closed accounts by default', async () => {
+    const accounts = [
+      { id: 'acc-1', name: 'Open Account', closed: false },
+      { id: 'acc-2', name: 'Closed Account', closed: true },
+    ];
+
+    mockFetchAllAccounts.mockResolvedValue(accounts);
+    mockGetAccountBalance.mockResolvedValue(100);
+
+    const fetcher = new GetAccountsDataFetcher();
+    const result = await fetcher.fetchAccounts({ includeClosed: false });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('acc-1');
+    expect(mockGetAccountBalance).toHaveBeenCalledTimes(1);
+    expect(mockGetAccountBalance).toHaveBeenCalledWith('acc-1');
+  });
+
+  it('includes closed accounts when requested', async () => {
+    const accounts = [
+      { id: 'acc-1', name: 'Open Account', closed: false },
+      { id: 'acc-2', name: 'Closed Account', closed: true },
+    ];
+
+    mockFetchAllAccounts.mockResolvedValue(accounts);
+    mockGetAccountBalance.mockResolvedValue(100);
+
+    const fetcher = new GetAccountsDataFetcher();
+    const result = await fetcher.fetchAccounts({ includeClosed: true });
+
+    expect(result).toHaveLength(2);
+    expect(mockGetAccountBalance).toHaveBeenCalledTimes(2);
+  });
+});

--- a/mcp-server/src/tools/get-accounts/data-fetcher.ts
+++ b/mcp-server/src/tools/get-accounts/data-fetcher.ts
@@ -64,10 +64,13 @@ export class GetAccountsDataFetcher {
       accounts = accounts.filter((a) => !a.closed);
     }
 
-    // Fetch balance for each account
-    for (const account of accounts) {
-      account.balance = await getAccountBalance(account.id);
-    }
+    // Fetch balance for each account in parallel
+    // Optimization: Use Promise.all to fetch balances concurrently instead of sequentially
+    await Promise.all(
+      accounts.map(async (account) => {
+        account.balance = await getAccountBalance(account.id);
+      })
+    );
 
     return accounts as AccountWithBalance[];
   }


### PR DESCRIPTION
💡 **What**: Replaced the sequential `for...of` loop in `GetAccountsDataFetcher.fetchAccounts` with `Promise.all` + `map`.
🎯 **Why**: The previous implementation fetched account balances one by one, leading to linear latency growth with the number of accounts.
📊 **Impact**: Reduces latency significantly. For N accounts, it reduces waiting time from `sum(latency_i)` to `max(latency_i)`.
🔬 **Measurement**: Validated with a benchmark test (deleted before commit) simulating 10 accounts with 100ms latency, showing ~10x speedup. Added a unit test to ensure functionality is preserved.

---
*PR created automatically by Jules for task [14390927246851937201](https://jules.google.com/task/14390927246851937201) started by @guitarbeat*