### PR TITLE
🔒 Fix CORS to validate origins (replaces #142)

### DIFF
--- a/mcp-server/src/core/transport/cors.test.ts
+++ b/mcp-server/src/core/transport/cors.test.ts
@@ -16,6 +16,7 @@ describe('corsMiddleware', () => {
       setHeader: vi.fn(),
       status: vi.fn().mockReturnThis(),
       end: vi.fn(),
+      json: vi.fn(),
       removeHeader: vi.fn(),
     };
     next = vi.fn();
@@ -60,7 +61,9 @@ describe('corsMiddleware', () => {
     req.headers!.origin = 'https://evil.com';
     corsMiddleware(req as Request, res as Response, next);
     expect(res.setHeader).not.toHaveBeenCalledWith('Access-Control-Allow-Origin', expect.anything());
-    expect(next).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Origin not allowed' });
+    expect(next).not.toHaveBeenCalled();
   });
 
   it('handles OPTIONS preflight for allowed origin', () => {
@@ -87,6 +90,8 @@ describe('corsMiddleware', () => {
     req.headers!.origin = 'invalid-url';
     corsMiddleware(req as Request, res as Response, next);
     expect(res.setHeader).not.toHaveBeenCalledWith('Access-Control-Allow-Origin', expect.anything());
-    expect(next).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Origin not allowed' });
+    expect(next).not.toHaveBeenCalled();
   });
 });

--- a/mcp-server/src/core/transport/cors.ts
+++ b/mcp-server/src/core/transport/cors.ts
@@ -61,5 +61,11 @@ export const corsMiddleware = (req: Request, res: Response, next: NextFunction):
     return;
   }
 
+  // Reject requests from unauthorized origins
+  if (!isAllowed) {
+    res.status(403).json({ error: 'Origin not allowed' });
+    return;
+  }
+
   next();
 };


### PR DESCRIPTION
This PR addresses a critical CORS security vulnerability by updating the middleware to actively reject requests from unauthorized origins with a 403 Forbidden status, rather than just omitting CORS headers. It maintains the existing whitelist logic (localhost, 127.0.0.1, and env var) and adds test coverage for the rejection behavior.

---
*PR created automatically by Jules for task [4002751956114130159](https://jules.google.com/task/4002751956114130159) started by @guitarbeat*