### PR TITLE
🛡️ Sentinel: Fix Input Validation in Financial Insights

### DIFF
--- a/mcp-server/src/core/analysis/financial-analyzer.ts
+++ b/mcp-server/src/core/analysis/financial-analyzer.ts
@@ -161,7 +161,6 @@ export async function findUncategorizedTransactions(month: string): Promise<Unca
     })
     .select(['amount', 'payee.name']);
 
-  // biome-ignore lint/suspicious/noExplicitAny: Dealing with external API response type
   const result = (await runAQL(query)) as { data: Array<{ amount: number; payee: { name: string } | null }> };
   const data = result.data;
 

--- a/mcp-server/src/core/types/schemas.ts
+++ b/mcp-server/src/core/types/schemas.ts
@@ -6,6 +6,38 @@
 import { z } from 'zod';
 
 // ----------------------------
+// Common Validation Schemas
+// ----------------------------
+
+/**
+ * Schema for UUID validation
+ */
+export const UUIDSchema = z.string().uuid();
+
+/**
+ * Schema for date string validation (YYYY-MM-DD format)
+ */
+export const DateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+
+/**
+ * Schema for month string validation (YYYY-MM format)
+ */
+export const MonthSchema = z.string().regex(/^\d{4}-\d{2}$/);
+
+/**
+ * Schema for amount validation (in cents)
+ */
+export const AmountSchema = z.number().int();
+
+/**
+ * Schema for optional date range
+ */
+export const DateRangeSchema = z.object({
+  startDate: DateSchema.optional(),
+  endDate: DateSchema.optional(),
+});
+
+// ----------------------------
 // Tool Argument Schemas
 // ----------------------------
 
@@ -131,8 +163,9 @@ export const BalanceHistoryArgsSchema = z.object({
 });
 
 export const FinancialInsightsArgsSchema = z.object({
-  startDate: z.string().optional(),
-  endDate: z.string().optional(),
+  month: MonthSchema.optional().describe('Month to analyze in YYYY-MM format. Defaults to current month.'),
+  includeSchedules: z.boolean().optional().describe('Include upcoming scheduled transactions. Default: true.'),
+  scheduleDays: z.number().optional().describe('Number of days ahead to look for scheduled transactions. Default: 14.'),
 });
 
 export const BudgetReviewArgsSchema = z.object({
@@ -293,35 +326,3 @@ export const DeleteScheduleArgsSchema = z.object({
 });
 
 export const GetSchedulesArgsSchema = z.object({});
-
-// ----------------------------
-// Common Validation Schemas
-// ----------------------------
-
-/**
- * Schema for UUID validation
- */
-export const UUIDSchema = z.string().uuid();
-
-/**
- * Schema for date string validation (YYYY-MM-DD format)
- */
-export const DateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
-
-/**
- * Schema for month string validation (YYYY-MM format)
- */
-export const MonthSchema = z.string().regex(/^\d{4}-\d{2}$/);
-
-/**
- * Schema for amount validation (in cents)
- */
-export const AmountSchema = z.number().int();
-
-/**
- * Schema for optional date range
- */
-export const DateRangeSchema = z.object({
-  startDate: DateSchema.optional(),
-  endDate: DateSchema.optional(),
-});

--- a/mcp-server/src/tools/financial-insights/index.ts
+++ b/mcp-server/src/tools/financial-insights/index.ts
@@ -3,9 +3,12 @@
 // Pre-analyzed financial summary to reduce context window load
 // ----------------------------
 
+import { zodToJsonSchema } from 'zod-to-json-schema';
 import { type FinancialInsightsSummary, generateInsightsSummary } from '../../core/analysis/financial-analyzer.js';
 import { formatAmount } from '../../core/formatting/index.js';
 import { errorFromCatch, successWithJson } from '../../core/response/index.js';
+import type { ToolInput } from '../../core/types/index.js';
+import { FinancialInsightsArgsSchema } from '../../core/types/schemas.js';
 
 export const schema = {
   name: 'get-financial-insights',
@@ -27,31 +30,8 @@ export const schema = {
     '- Specific month: {"month": "2024-01"}\\n' +
     '- Extended forecast: {"scheduleDays": 30}\\n\\n' +
     'NOTE: This tool performs server-side analysis to provide concise insights.',
-  inputSchema: {
-    type: 'object',
-    properties: {
-      month: {
-        type: 'string',
-        description: 'Month to analyze in YYYY-MM format. Defaults to current month.',
-      },
-      includeSchedules: {
-        type: 'boolean',
-        description: 'Include upcoming scheduled transactions. Default: true.',
-      },
-      scheduleDays: {
-        type: 'number',
-        description: 'Number of days ahead to look for scheduled transactions. Default: 14.',
-      },
-    },
-    required: [],
-  },
+  inputSchema: zodToJsonSchema(FinancialInsightsArgsSchema) as ToolInput,
 };
-
-interface FinancialInsightsArgs {
-  month?: string;
-  includeSchedules?: boolean;
-  scheduleDays?: number;
-}
 
 /**
  * Format the insights summary for display
@@ -105,12 +85,13 @@ function formatInsights(insights: FinancialInsightsSummary): object {
  * Handler for the get-financial-insights tool
  */
 export async function handler(
-  args: FinancialInsightsArgs
+  args: unknown
 ): Promise<ReturnType<typeof successWithJson> | ReturnType<typeof errorFromCatch>> {
   try {
-    const insights = await generateInsightsSummary(args.month, {
-      includeSchedules: args.includeSchedules,
-      scheduleDays: args.scheduleDays,
+    const input = FinancialInsightsArgsSchema.parse(args);
+    const insights = await generateInsightsSummary(input.month, {
+      includeSchedules: input.includeSchedules,
+      scheduleDays: input.scheduleDays,
     });
 
     return successWithJson(formatInsights(insights));

--- a/mcp-server/src/tools/financial-insights/schema.test.ts
+++ b/mcp-server/src/tools/financial-insights/schema.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { FinancialInsightsArgsSchema } from '../../core/types/schemas.js';
+
+describe('FinancialInsightsArgsSchema', () => {
+  it('should validate valid month', () => {
+    const validData = {
+      month: '2023-10',
+    };
+    const result = FinancialInsightsArgsSchema.safeParse(validData);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate empty input (defaults)', () => {
+    const validData = {};
+    const result = FinancialInsightsArgsSchema.safeParse(validData);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject invalid month format', () => {
+    const invalidInputs = [
+      '2023-1',       // Too short
+      '2023-100',     // Too long
+      '23-10',        // Short year
+      '2023/10',      // Wrong separator
+      'October 2023', // Name
+      // SQL/AQL Injection attempts
+      "2023-10' OR 1=1",
+      "2023-10; DROP TABLE users",
+      "2023-10\nDELETE FROM transactions",
+    ];
+
+    for (const input of invalidInputs) {
+      const result = FinancialInsightsArgsSchema.safeParse({ month: input });
+      expect(result.success).toBe(false);
+    }
+  });
+
+  it('should validate optional boolean and number fields', () => {
+    const validData = {
+      month: '2023-10',
+      includeSchedules: false,
+      scheduleDays: 30,
+    };
+    const result = FinancialInsightsArgsSchema.safeParse(validData);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject invalid types for other fields', () => {
+    const invalidData = {
+      includeSchedules: 'yes', // should be boolean
+      scheduleDays: '30',      // should be number
+    };
+    const result = FinancialInsightsArgsSchema.safeParse(invalidData);
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Input Validation in Financial Insights

🚨 Severity: HIGH
💡 Vulnerability: The `get-financial-insights` tool lacked strict input validation for the `month` parameter, relying on manual handling which could potentially lead to AQL/SQL injection or logic errors with malformed date strings (e.g., `'2024-01' OR 1=1`).
🎯 Impact: An attacker could potentially manipulate the database query or cause the server to crash/behave unexpectedly by providing crafted input strings.
🔧 Fix: Implemented strict Zod schema validation using `MonthSchema` (regex `^\d{4}-\d{2}$`) and updated the tool to parse arguments against this schema.
✅ Verification: Added a new regression test suite `mcp-server/src/tools/financial-insights/schema.test.ts` that explicitly tests valid and invalid inputs, including injection attempts. Run `pnpm run test:unit -- mcp-server/src/tools/financial-insights/schema.test.ts` to verify.

---
*PR created automatically by Jules for task [5125772988921813926](https://jules.google.com/task/5125772988921813926) started by @guitarbeat*