### PR TITLE
⚡ Bolt: Use in-place sort in GroupAggregator

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@ This journal records critical performance learnings, anti-patterns, and architec
 ## 2026-02-08 - [Object Iteration vs Array Allocation]
 **Learning:** When aggregating data from a large object (Record), using `for...in` loop is significantly faster (~15%) than `Object.values()` or `Object.entries()` because it avoids allocating an intermediate array of keys or values.
 **Action:** For performance-critical loops over large objects, prefer `for...in` combined with incremental processing (e.g. summing) to minimize allocations and passes.
+
+## 2026-02-15 - [In-Place Sorting]
+**Learning:** `Array.prototype.sort` is significantly more memory-efficient than immutable sort utilities (like `sortBy`) for locally-constructed arrays because it avoids creating intermediate copies.
+**Action:** Use in-place `sort` for aggregators and data transformers where the array is owned by the current scope, reserving `sortBy` only for cases where immutability of the input is required.

--- a/mcp-server/src/core/aggregation/group-by.ts
+++ b/mcp-server/src/core/aggregation/group-by.ts
@@ -1,6 +1,5 @@
 // Aggregates category spendings into groups and sorts them
 import type { CategorySpending, GroupSpending } from '../types/domain.js';
-import { sortBy } from './sort-by.js';
 
 /**
  * Aggregates category spending data into groups and sorts by total spending.
@@ -43,18 +42,22 @@ export class GroupAggregator {
     const groups: GroupSpending[] = [];
 
     for (const [groupName, { total, categories }] of groupsMap) {
-      // Sort categories within the group
-      const sortedCategories = sortBy(categories, [(cat) => Math.abs(cat.total)], ['desc']);
+      // Sort categories within the group in-place
+      // Optimization: Use in-place sort to avoid memory allocation from sortBy's copy
+      categories.sort((a, b) => Math.abs(b.total) - Math.abs(a.total));
 
       groups.push({
         name: groupName,
         total,
-        categories: sortedCategories,
+        categories: categories, // categories is now sorted in-place
       });
     }
 
-    // Sort groups by absolute total (descending)
-    return sortBy(groups, [(group) => Math.abs(group.total)], ['desc']);
+    // Sort groups by absolute total (descending) in-place
+    // Optimization: Use in-place sort to avoid memory allocation from sortBy's copy
+    groups.sort((a, b) => Math.abs(b.total) - Math.abs(a.total));
+
+    return groups;
   }
 
   /**


### PR DESCRIPTION
* 💡 What: Replaced `sortBy` utility with `Array.prototype.sort` in `GroupAggregator.aggregateAndSort`.
* 🎯 Why: To avoid unnecessary array copying and memory allocation during aggregation.
* 📊 Impact: Reduces memory pressure (GC) by avoiding intermediate array copies for categories and groups.
* 🔬 Measurement: Verified with unit tests (`src/core/aggregation/group-by.test.ts`).

---
*PR created automatically by Jules for task [4236262071218149119](https://jules.google.com/task/4236262071218149119) started by @guitarbeat*