### PR TITLE
fix(aggregation): clean up sort-by.ts lint directives

### DIFF
--- a/mcp-server/src/core/aggregation/sort-by.ts
+++ b/mcp-server/src/core/aggregation/sort-by.ts
@@ -21,11 +21,11 @@ export function sortBy<T>(
     return [...array].sort((a, b) => {
       const valA = iteratee(a);
       const valB = iteratee(b);
-      // biome-ignore lint/suspicious/noExplicitAny: Comparison of unknown types requires loose typing
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Comparison of unknown types requires loose typing
       if ((valA as any) < (valB as any)) {
         return -1 * multiplier;
       }
-      // biome-ignore lint/suspicious/noExplicitAny: Comparison of unknown types requires loose typing
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Comparison of unknown types requires loose typing
       if ((valA as any) > (valB as any)) {
         return 1 * multiplier;
       }
@@ -50,11 +50,11 @@ export function sortBy<T>(
 }
 
 function compare(a: unknown, b: unknown, order: 'asc' | 'desc'): number {
-  // biome-ignore lint/suspicious/noExplicitAny: Comparison of unknown types requires loose typing
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Comparison of unknown types requires loose typing
   if ((a as any) < (b as any)) {
     return order === 'asc' ? -1 : 1;
   }
-  // biome-ignore lint/suspicious/noExplicitAny: Comparison of unknown types requires loose typing
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Comparison of unknown types requires loose typing
   if ((a as any) > (b as any)) {
     return order === 'asc' ? 1 : -1;
   }


### PR DESCRIPTION
This PR addresses the issue of potentially empty aggregation modules. Upon inspection, `sum-by.ts` and `sort-by.ts` were found to be fully implemented and working. However, `sort-by.ts` contained `biome-ignore` comments which were not effective for the project's ESLint setup, causing lint warnings. This change replaces them with correct `eslint-disable` directives, ensuring the code is clean and compliant.

Testing:
- `pnpm run lint` confirms warnings are gone in `sort-by.ts`.
- `pnpm run test:unit -- src/core/aggregation/sort-by.test.ts` passed.

---
*PR created automatically by Jules for task [16796440944809768827](https://jules.google.com/task/16796440944809768827) started by @guitarbeat*