### PR TITLE
feat(mcp-server): Add security hardening and rate limiting

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -46,6 +46,8 @@
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.4",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.2.1",
+    "helmet": "^8.1.0",
     "lru-cache": "^11.2.5",
     "openai": "^6.18.0",
     "zod": "^3.25.76",

--- a/mcp-server/pnpm-lock.yaml
+++ b/mcp-server/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      express-rate-limit:
+        specifier: ^8.2.1
+        version: 8.2.1(express@5.2.1)
+      helmet:
+        specifier: ^8.1.0
+        version: 8.1.0
       lru-cache:
         specifier: ^11.2.5
         version: 11.2.5
@@ -1543,6 +1549,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  helmet@8.1.0:
+    resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
+    engines: {node: '>=18.0.0'}
 
   hono@4.11.7:
     resolution: {integrity: sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==}
@@ -4345,6 +4355,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  helmet@8.1.0: {}
 
   hono@4.11.7: {}
 

--- a/mcp-server/src/core/transport/security-headers.test.ts
+++ b/mcp-server/src/core/transport/security-headers.test.ts
@@ -3,24 +3,15 @@ import type { Request, Response, NextFunction } from 'express';
 import { securityHeaders } from './security-headers.js';
 
 describe('securityHeaders', () => {
-  it('should set security headers', () => {
+  it('should set custom Content-Security-Policy and nonce', () => {
     const req = {} as Request;
     const res = {
       setHeader: vi.fn(),
-      removeHeader: vi.fn(),
       locals: {},
     } as unknown as Response;
     const next = vi.fn() as NextFunction;
 
     securityHeaders(req, res, next);
-
-    expect(res.setHeader).toHaveBeenCalledWith('X-Content-Type-Options', 'nosniff');
-    expect(res.setHeader).toHaveBeenCalledWith('X-Frame-Options', 'DENY');
-    expect(res.setHeader).toHaveBeenCalledWith(
-      'Strict-Transport-Security',
-      'max-age=31536000; includeSubDomains',
-    );
-    expect(res.setHeader).toHaveBeenCalledWith('Referrer-Policy', 'no-referrer');
 
     // Verify nonce generation and CSP
     expect(res.locals.nonce).toBeDefined();
@@ -30,7 +21,6 @@ describe('securityHeaders', () => {
       `default-src 'self'; img-src 'self' data:; style-src 'self' 'nonce-${res.locals.nonce}'; script-src 'self' 'nonce-${res.locals.nonce}'; frame-ancestors 'none';`,
     );
 
-    expect(res.removeHeader).toHaveBeenCalledWith('X-Powered-By');
     expect(next).toHaveBeenCalled();
   });
 });

--- a/mcp-server/src/core/transport/security-headers.ts
+++ b/mcp-server/src/core/transport/security-headers.ts
@@ -13,17 +13,8 @@ import type { NextFunction, Request, Response } from 'express';
  * - Removal of X-Powered-By
  */
 export const securityHeaders = (_req: Request, res: Response, next: NextFunction): void => {
-  // Prevent MIME type sniffing
-  res.setHeader('X-Content-Type-Options', 'nosniff');
-
-  // Prevent clickjacking
-  res.setHeader('X-Frame-Options', 'DENY');
-
-  // Enforce HTTPS
-  res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
-
-  // Control referrer information
-  res.setHeader('Referrer-Policy', 'no-referrer');
+  // Note: helmet handles standard security headers (like X-Frame-Options, X-Content-Type-Options,
+  // Strict-Transport-Security, X-Powered-By, etc.) globally in index.ts. We only set custom CSP here.
 
   // Generate a nonce for inline scripts
   const nonce = randomBytes(16).toString('base64');
@@ -39,9 +30,6 @@ export const securityHeaders = (_req: Request, res: Response, next: NextFunction
     'Content-Security-Policy',
     `default-src 'self'; img-src 'self' data:; style-src 'self' 'nonce-${nonce}'; script-src 'self' 'nonce-${nonce}'; frame-ancestors 'none';`,
   );
-
-  // Remove X-Powered-By header to hide server details
-  res.removeHeader('X-Powered-By');
 
   next();
 };

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -20,7 +20,9 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import dotenv from 'dotenv';
-import type { Request, Response } from 'express';
+import express, { type Request, type Response } from 'express';
+import rateLimit from 'express-rate-limit';
+import helmet from 'helmet';
 import {
   getInitializationStats,
   initActualApi,
@@ -396,6 +398,21 @@ async function main(): Promise<void> {
       // * When bearer auth is disabled, restrict to localhost for security.
       allowedHosts: enableBearer ? undefined : ['localhost', '127.0.0.1'],
     });
+
+    // * Enforce a 1MB payload limit for JSON bodies
+    app.use(express.json({ limit: '1mb' }));
+
+    // * Helmet security headers (Content Security Policy is managed by custom securityHeaders middleware)
+    app.use(helmet({ contentSecurityPolicy: false }));
+
+    // * Rate limiting: maximum of 100 requests per 15 minutes
+    const apiLimiter = rateLimit({
+      windowMs: 15 * 60 * 1000,
+      max: 100,
+      standardHeaders: true,
+      legacyHeaders: false,
+    });
+    app.use(apiLimiter);
 
     // * Security Headers
     app.use(securityHeaders);


### PR DESCRIPTION
Added security middleware for `mcp-server` based on user requirements to harden the application. This includes:
- Adding `helmet` and `express-rate-limit` as dependencies via `pnpm add`.
- Applying `helmet` globally to set various HTTP security headers like HSTS, X-Content-Type-Options, etc.
- Removing duplicated header overrides in the custom `security-headers.ts` in favor of Helmet.
- Updating `security-headers.test.ts` to align with the new responsibilities.
- Using `app.use(express.json({ limit: '1mb' }))` to constrain JSON payload sizes against potential abuse.
- Adding a global rate limiter constrained at 100 requests per 15 minutes for APIs.

---
*PR created automatically by Jules for task [13232817405367808452](https://jules.google.com/task/13232817405367808452) started by @guitarbeat*