### PR TITLE
chore: remove VERIFY FIX comments from StreamableHTTPHandler tests

### DIFF
--- a/mcp-server/src/core/transport/streamable-http-handler.test.ts
+++ b/mcp-server/src/core/transport/streamable-http-handler.test.ts
@@ -54,12 +54,12 @@ describe('StreamableHTTPHandler Security', () => {
 
     expect(res.statusCode).toBe(500);
 
-    // VERIFY FIX: The sensitive error message should NOT be included in the response
+    // The sensitive error message should NOT be included in the response
     expect(res.end).not.toHaveBeenCalledWith(
       expect.stringContaining('Sensitive database password exposed!'),
     );
 
-    // VERIFY FIX: The response should contain the generic error message
+    // The response should contain the generic error message
     expect(res.end).toHaveBeenCalledWith(expect.stringContaining('Internal server error'));
   });
 });


### PR DESCRIPTION
## **User description**
The StreamableHTTPHandler tests correctly verify that sensitive database errors are NOT exposed in 500 error responses and a generic error is returned instead. Since this isn't a bug in the implementation, just test verification comments, we simply removed the `VERIFY FIX:` prefix.

---
*PR created automatically by Jules for task [12422253602829530399](https://jules.google.com/task/12422253602829530399) started by @guitarbeat*

## Summary by Sourcery

Chores:
- Clean up StreamableHTTPHandler security tests by removing VERIFY FIX markers from assertions about non-exposure of sensitive errors.


___

## **CodeAnt-AI Description**
Keep the StreamableHTTPHandler security test comments plain and readable

### What Changed
- Removed the `VERIFY FIX` prefix from test comments while keeping the same security checks in place
- The test still confirms sensitive database errors are not shown to users and that a generic internal server error is returned

### Impact
`✅ Clearer test expectations`
`✅ Easier security test maintenance`
`✅ No change to error responses`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
