### PR TITLE
fix: commit polyfill.cjs and use it in startup smoke test to fix CI build

### DIFF
--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -28,7 +28,8 @@ COPY --from=builder /out ./
 # Polyfill browser globals required by @actual-app/api at module load time.
 # navigator.platform is referenced at the top level of bundle.api.js; Node.js
 # has no navigator global so the process crashes on startup without this.
-RUN echo 'if (typeof globalThis.navigator === "undefined") { globalThis.navigator = { platform: process.platform, userAgent: "node" }; }' > polyfill.cjs
+# The file is committed to the repo so the smoke test can also --require it.
+COPY mcp-server/polyfill.cjs ./polyfill.cjs
 
 ENV NODE_ENV=production
 EXPOSE 3000

--- a/mcp-server/polyfill.cjs
+++ b/mcp-server/polyfill.cjs
@@ -1,0 +1,6 @@
+// Polyfill browser globals required by @actual-app/api at module load time.
+// navigator.platform is referenced at the top level of bundle.api.js; Node.js
+// has no navigator global so the process crashes on startup without this.
+if (typeof globalThis.navigator === 'undefined') {
+  globalThis.navigator = { platform: process.platform, userAgent: 'node' };
+}

--- a/mcp-server/scripts/startup-smoke.ts
+++ b/mcp-server/scripts/startup-smoke.ts
@@ -91,7 +91,15 @@ async function main(): Promise<void> {
   const port = await getFreePort();
   const child = spawn(
     process.execPath,
-    ['build/index.js', '--sse', '--enable-bearer', '--port', String(port)],
+    [
+      '--require',
+      resolve(packageRoot, 'polyfill.cjs'),
+      'build/index.js',
+      '--sse',
+      '--enable-bearer',
+      '--port',
+      String(port),
+    ],
     {
       cwd: packageRoot,
       env: {


### PR DESCRIPTION
## Problem

The CI "Build" job was failing because the startup smoke test spawned `build/index.js` **without** the `--require polyfill.cjs` flag that the Docker `ENTRYPOINT` uses.

`@actual-app/api` references `navigator.platform` at the top level of `bundle.api.js`. Node.js 20 has no `navigator` global, so the process crashes immediately with:

```
ReferenceError: navigator is not defined
```

The Docker image worked fine because the `ENTRYPOINT` injects the polyfill via `--require ./polyfill.cjs`. CI didn't, so the smoke test always failed.

## Fix

1. **Commit `mcp-server/polyfill.cjs`** to the repo as a real file instead of generating it inline with `RUN echo ...` in the Dockerfile.
2. **Update `Dockerfile`** release stage to `COPY mcp-server/polyfill.cjs ./polyfill.cjs` — same behavior, but now sourced from the repo.
3. **Update `startup-smoke.ts`** to pass `--require resolve(packageRoot, 'polyfill.cjs')` in the spawn args, so CI and Docker use identical startup paths.

## Files changed

| File | Change |
|------|--------|
| `mcp-server/polyfill.cjs` | ✨ New file — navigator polyfill |
| `mcp-server/Dockerfile` | `RUN echo ...` → `COPY mcp-server/polyfill.cjs` |
| `mcp-server/scripts/startup-smoke.ts` | Add `--require polyfill.cjs` to spawn args |

## Summary by Sourcery

Ensure the MCP server uses a shared navigator polyfill in both Docker and CI startup smoke tests to avoid Node.js startup crashes.

Bug Fixes:
- Fix CI build failures by requiring the navigator polyfill when running the startup smoke test.

Enhancements:
- Commit the navigator polyfill as a source file and reuse it in the Docker image instead of generating it inline in the Dockerfile.

Tests:
- Align the startup smoke test process invocation with the Docker entrypoint by requiring the shared polyfill script.