### PR TITLE
test(mcp-server): add error path tests for get-budget-month validation

### DIFF
--- a/mcp-server/src/tools/budgets/get-budget/index.test.ts
+++ b/mcp-server/src/tools/budgets/get-budget/index.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handler, validateMonthFormat } from './index.js';
+import { getBudgetMonth, getBudgetMonths } from '../../../core/api/actual-client.js';
+
+vi.mock('../../../core/api/actual-client.js', () => ({
+  getBudgetMonth: vi.fn(),
+  getBudgetMonths: vi.fn(),
+}));
+
+function parseJsonResponse(response: any): Record<string, unknown> {
+  const firstContent = response.content[0];
+  if (!('text' in firstContent)) {
+    throw new Error('Expected text content');
+  }
+  return JSON.parse(firstContent.text) as Record<string, unknown>;
+}
+
+describe('get-budget-month tool', () => {
+  describe('validateMonthFormat', () => {
+    it('should pass for valid YYYY-MM format', () => {
+      expect(() => validateMonthFormat('2024-01')).not.toThrow();
+      expect(() => validateMonthFormat('2100-12')).not.toThrow();
+      expect(() => validateMonthFormat('1900-01')).not.toThrow();
+    });
+
+    it('should throw for invalid format regex', () => {
+      expect(() => validateMonthFormat('2024-1')).toThrow('Invalid month format');
+      expect(() => validateMonthFormat('24-01')).toThrow('Invalid month format');
+      expect(() => validateMonthFormat('abc')).toThrow('Invalid month format');
+      expect(() => validateMonthFormat('2024/01')).toThrow('Invalid month format');
+    });
+
+    it('should throw for year out of range', () => {
+      expect(() => validateMonthFormat('1899-12')).toThrow('Invalid year');
+      expect(() => validateMonthFormat('2101-01')).toThrow('Invalid year');
+    });
+
+    it('should throw for month out of range', () => {
+      expect(() => validateMonthFormat('2024-00')).toThrow('Invalid month');
+      expect(() => validateMonthFormat('2024-13')).toThrow('Invalid month');
+    });
+  });
+
+  describe('handler', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should return budget for a valid month', async () => {
+      const mockBudget = { month: '2024-01', categories: [] };
+      vi.mocked(getBudgetMonth).mockResolvedValue(mockBudget);
+
+      const response = await handler({ month: '2024-01' });
+      const payload = parseJsonResponse(response);
+
+      expect(getBudgetMonth).toHaveBeenCalledWith('2024-01');
+      expect(payload).toEqual(mockBudget);
+      expect(response.isError).toBeUndefined();
+    });
+
+    it('should return available months if month is omitted', async () => {
+      const mockMonths = ['2024-01', '2024-02'];
+      vi.mocked(getBudgetMonths).mockResolvedValue(mockMonths);
+
+      const response = await handler({});
+      const payload = parseJsonResponse(response);
+
+      expect(getBudgetMonths).toHaveBeenCalled();
+      expect(payload).toEqual(mockMonths);
+      expect(response.isError).toBeUndefined();
+    });
+
+    it('should return error if month is not a string', async () => {
+      const response = await handler({ month: 123 });
+      const payload = parseJsonResponse(response);
+
+      expect(response.isError).toBe(true);
+      expect(payload.message).toContain('month must be a string');
+    });
+
+    it('should return error if month fails validation', async () => {
+      const response = await handler({ month: 'invalid' });
+      const payload = parseJsonResponse(response);
+
+      expect(response.isError).toBe(true);
+      expect(payload.message).toContain('Invalid month format');
+    });
+
+    it('should handle "not found" API error specifically', async () => {
+      vi.mocked(getBudgetMonth).mockRejectedValue(new Error('Budget not found'));
+
+      const response = await handler({ month: '2024-01' });
+      const payload = parseJsonResponse(response);
+
+      expect(response.isError).toBe(true);
+      expect(payload.message).toContain('Budget data not found for month 2024-01');
+    });
+
+    it('should handle generic API errors', async () => {
+      vi.mocked(getBudgetMonth).mockRejectedValue(new Error('Some API error'));
+
+      const response = await handler({ month: '2024-01' });
+      const payload = parseJsonResponse(response);
+
+      expect(response.isError).toBe(true);
+      expect(payload.message).toContain('Failed to retrieve budget data');
+    });
+  });
+});

--- a/mcp-server/src/tools/budgets/get-budget/index.ts
+++ b/mcp-server/src/tools/budgets/get-budget/index.ts
@@ -40,7 +40,7 @@ export const schema = {
  * @param month - Month string to validate
  * @throws Error if format is invalid
  */
-function validateMonthFormat(month: string): void {
+export function validateMonthFormat(month: string): void {
   // Check format matches YYYY-MM pattern
   if (!/^\d{4}-\d{2}$/.test(month)) {
     throw new Error('Invalid month format. Expected YYYY-MM format (e.g., 2024-01)');


### PR DESCRIPTION
test(mcp-server): add error path tests for get-budget-month validation

- Export `validateMonthFormat` from `get-budget/index.ts` for unit testing.
- Add `get-budget/index.test.ts` with comprehensive unit and integration tests.
- Cover valid format, invalid format regex, year out of range, and month out of range.
- Cover `handler` success and error paths, including specific "not found" API error handling.

---
Created from Jules session `sessions/10025026225082615044`
Jules URL: https://jules.google.com/session/10025026225082615044

## Summary by Sourcery

Add unit and integration tests for the get-budget-month tool and expose its month format validator for direct testing.

Enhancements:
- Export validateMonthFormat from the get-budget-month module to enable direct unit testing.

Tests:
- Add comprehensive tests for validateMonthFormat covering valid formats and multiple invalid cases.
- Add handler tests for successful responses, validation failures, missing month, and specific API error scenarios.