### PR TITLE
🔒 fix: robust bearer token redaction in logger

### DIFF
--- a/mcp-server/src/core/logging/safe-logger.ts
+++ b/mcp-server/src/core/logging/safe-logger.ts
@@ -37,7 +37,7 @@ const performanceMetrics: Map<string, { start: number; end?: number; duration?: 
 // Sensitive data patterns for redaction
 const SENSITIVE_KEY_REGEX =
   /pass(word|phrase)|(?<!(input|output|max|total)_)token|secret|(private|api|access).?key|authorization|bearer|credential/i;
-const BEARER_TOKEN_REGEX = /Bearer\s+([a-zA-Z0-9._-]+)/gi;
+const BEARER_TOKEN_REGEX = /(Bearer\s+)[a-zA-Z0-9\-._~+/]+=*/gi;
 
 /**
  * Redacts sensitive information from objects and strings.
@@ -55,10 +55,8 @@ function redactValue(key: string, value: unknown): unknown {
 
   // Redact sensitive patterns in string values
   if (typeof value === 'string') {
-    // Redact Bearer tokens
-    if (value.match(BEARER_TOKEN_REGEX)) {
-      return value.replace(BEARER_TOKEN_REGEX, 'Bearer [REDACTED]');
-    }
+    // Redact Bearer tokens using capture groups to preserve prefix/whitespace
+    return value.replace(BEARER_TOKEN_REGEX, '$1[REDACTED]');
   }
 
   return value;
@@ -228,8 +226,8 @@ export function formatMessage(args: unknown[]): string {
           return JSON.stringify(arg, redactValue, 2);
         } catch {
           // Fallback to basic string representation if stringify fails
-          // We can't easily redact here without string parsing, but this case is rare (circular refs)
-          return String(arg);
+          // Ensure we still attempt to redact sensitive patterns from the resulting string
+          return String(redactValue('', String(arg)));
         }
       }
       // Handle primitive strings that might contain sensitive data


### PR DESCRIPTION
🔒 fix: robust bearer token redaction in logger

- Updated BEARER_TOKEN_REGEX to include '+', '/', '=', and '~' characters.
- Optimized redactValue to use .replace() directly with capture groups.
- Added redaction fallback for circular objects in formatMessage.
- Preserved whitespace and casing in Bearer prefix during redaction.

---
Created from Jules session `sessions/10286326380423868361`
Jules URL: https://jules.google.com/session/10286326380423868361

## Summary by Sourcery

Improve logging safety by more robustly redacting bearer tokens in log messages, including for non-JSON and circular-reference cases.

Bug Fixes:
- Expand bearer token detection to cover additional valid characters and padding used in tokens.
- Preserve the original Bearer prefix formatting while redacting token values in logged strings.
- Ensure log formatting still applies redaction to stringified values when JSON serialization fails, such as with circular references.