### PR TITLE
chore: remove commented out code and stale optimization comments

### DIFF
--- a/mcp-server/src/core/aggregation/group-by.ts
+++ b/mcp-server/src/core/aggregation/group-by.ts
@@ -67,7 +67,6 @@ export class GroupAggregator {
    * @returns Record mapping IDs to items
    */
   byId<T extends { id: string }>(list: T[]): Record<string, T> {
-    // Optimization: Use for...of loop instead of reduce to avoid function call overhead
     const result: Record<string, T> = {};
     for (const item of list) {
       result[item.id] = item;

--- a/mcp-server/src/core/index.ts
+++ b/mcp-server/src/core/index.ts
@@ -14,7 +14,6 @@ export * from './data/fetch-rules.js';
 export * from './data/fetch-transactions.js';
 export * from './data/index.js';
 export * from './input/argument-parser.js';
-// export * from './input/validators.js'; // Avoid conflicts
 export { DateSchema, MonthSchema, UUIDSchema } from './input/validators.js';
 export * from './logging/index.js';
 export * from './mapping/category-classifier.js';

--- a/mcp-server/src/core/utils/name-resolver.bench.test.ts
+++ b/mcp-server/src/core/utils/name-resolver.bench.test.ts
@@ -37,8 +37,5 @@ describe('NameResolver N+1 Benchmark', () => {
 
     console.log(`Duration for 100 missing lookups: ${duration.toFixed(2)}ms`);
     console.log(`fetchAllAccounts called ${vi.mocked(fetchAllAccounts).mock.calls.length} times`);
-
-    // We expect it to be called 100 times in the unoptimized version
-    // expect(vi.mocked(fetchAllAccounts).mock.calls.length).toBe(100);
   });
 });

--- a/mcp-server/src/tools/rules/get-rules/index.ts
+++ b/mcp-server/src/tools/rules/get-rules/index.ts
@@ -3,7 +3,6 @@
 // ----------------------------
 
 import type { RuleEntity } from '@actual-app/api/@types/loot-core/src/types/models/rule.js';
-// import type { Rule } from '../../../core/types/index.js';
 import { fetchAllRules } from '../../../core/data/fetch-rules.js';
 import { errorFromCatch, successWithJson } from '../../../core/response/index.js';
 


### PR DESCRIPTION
chore: remove commented out code and stale optimization comments

- Remove flagged optimization comment in mcp-server/src/core/aggregation/group-by.ts
- Remove commented out export in mcp-server/src/core/index.ts
- Remove commented out test assertion in mcp-server/src/core/utils/name-resolver.bench.test.ts
- Remove commented out import in mcp-server/src/tools/rules/get-rules/index.ts

---
Created from Jules session `sessions/16496945810490408667`
Jules URL: https://jules.google.com/session/16496945810490408667

## Summary by Sourcery

Remove unused commented-out code and stale optimization comments from core and tools modules.

Chores:
- Clean up commented-out benchmark assertion and logged expectations in name-resolver benchmark test.
- Remove outdated optimization comment in GroupAggregator.byId implementation.
- Delete unused commented-out exports and imports in core index and rules tool entrypoint.