### PR TITLE
refactor: extract redaction logic from safe-logger.ts

### DIFF
--- a/mcp-server/src/core/logging/index.ts
+++ b/mcp-server/src/core/logging/index.ts
@@ -11,3 +11,5 @@ export {
   withRequestId,
   withRequestIdAsync,
 } from './safe-logger.js';
+
+export { redactValue } from './redactor.js';

--- a/mcp-server/src/core/logging/redactor.test.ts
+++ b/mcp-server/src/core/logging/redactor.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { redactValue } from './redactor.js';
+
+describe('redactValue', () => {
+  it('should redact sensitive keys', () => {
+    expect(redactValue('password', 'secret123')).toBe('[REDACTED]');
+    expect(redactValue('apiKey', 'sk_live_123')).toBe('[REDACTED]');
+    expect(redactValue('authorization', 'Bearer token')).toBe('[REDACTED]');
+    expect(redactValue('secret', 'my-secret')).toBe('[REDACTED]');
+  });
+
+  it('should redact Bearer tokens in strings', () => {
+    const input = 'Request with Authorization: Bearer secret-token-123 failed';
+    const result = redactValue('', input);
+    expect(result).toBe('Request with Authorization: Bearer [REDACTED] failed');
+  });
+
+  it('should NOT redact safe keys', () => {
+    expect(redactValue('author', 'John Doe')).toBe('John Doe');
+    expect(redactValue('authentication', 'public')).toBe('public');
+    expect(redactValue('authority', 'admin')).toBe('admin');
+  });
+
+  it('should NOT redact usage metrics with token in name', () => {
+    expect(redactValue('input_tokens', 150)).toBe(150);
+    expect(redactValue('output_tokens', 50)).toBe(50);
+    expect(redactValue('max_tokens', 1000)).toBe(1000);
+  });
+
+  it('should redact standalone token key', () => {
+    expect(redactValue('token', 'secret-token')).toBe('[REDACTED]');
+  });
+
+  it('should handle non-string values gracefully', () => {
+    expect(redactValue('someKey', 123)).toBe(123);
+    expect(redactValue('someKey', { a: 1 })).toEqual({ a: 1 });
+    expect(redactValue('someKey', null)).toBe(null);
+  });
+});

--- a/mcp-server/src/core/logging/redactor.ts
+++ b/mcp-server/src/core/logging/redactor.ts
@@ -1,0 +1,32 @@
+/**
+ * Redaction utility for sensitive information.
+ * Extracts and centralizes redaction of sensitive data like passwords, tokens, and keys.
+ */
+
+// Sensitive data patterns for redaction
+const SENSITIVE_KEY_REGEX =
+  /pass(word|phrase)|(?<!(input|output|max|total)_)token|secret|(private|api|access).?key|authorization|bearer|credential/i;
+const BEARER_TOKEN_REGEX = /(Bearer\s+)[a-zA-Z0-9\-._~+/]+=*/gi;
+
+/**
+ * Redacts sensitive information from objects and strings.
+ * Used as a JSON.stringify replacer or standalone value processor.
+ *
+ * @param key - The object key (if applicable)
+ * @param value - The value to check and potentially redact
+ * @returns The original value or a redacted string
+ */
+export function redactValue(key: string, value: unknown): unknown {
+  // Redact based on key name
+  if (key && SENSITIVE_KEY_REGEX.test(key)) {
+    return '[REDACTED]';
+  }
+
+  // Redact sensitive patterns in string values
+  if (typeof value === 'string') {
+    // Redact Bearer tokens using capture groups to preserve prefix/whitespace
+    return value.replace(BEARER_TOKEN_REGEX, '$1[REDACTED]');
+  }
+
+  return value;
+}

--- a/mcp-server/src/core/logging/safe-logger.ts
+++ b/mcp-server/src/core/logging/safe-logger.ts
@@ -12,6 +12,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { randomUUID } from 'node:crypto';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { redactValue } from './redactor.js';
 
 /**
  * Store original console methods before overriding
@@ -34,33 +35,6 @@ const performanceEnabled = process.env.DEBUG_PERFORMANCE === 'true';
 const performanceMetrics: Map<string, { start: number; end?: number; duration?: number }> =
   new Map();
 
-// Sensitive data patterns for redaction
-const SENSITIVE_KEY_REGEX =
-  /pass(word|phrase)|(?<!(input|output|max|total)_)token|secret|(private|api|access).?key|authorization|bearer|credential/i;
-const BEARER_TOKEN_REGEX = /(Bearer\s+)[a-zA-Z0-9\-._~+/]+=*/gi;
-
-/**
- * Redacts sensitive information from objects and strings.
- * Used as a JSON.stringify replacer or standalone value processor.
- *
- * @param key - The object key (if applicable)
- * @param value - The value to check and potentially redact
- * @returns The original value or a redacted string
- */
-function redactValue(key: string, value: unknown): unknown {
-  // Redact based on key name
-  if (key && SENSITIVE_KEY_REGEX.test(key)) {
-    return '[REDACTED]';
-  }
-
-  // Redact sensitive patterns in string values
-  if (typeof value === 'string') {
-    // Redact Bearer tokens using capture groups to preserve prefix/whitespace
-    return value.replace(BEARER_TOKEN_REGEX, '$1[REDACTED]');
-  }
-
-  return value;
-}
 
 /**
  * Setup safe logging for stdio mode.


### PR DESCRIPTION
refactor: extract redaction logic from safe-logger.ts

Extracted redaction logic (including SENSITIVE_KEY_REGEX, BEARER_TOKEN_REGEX, and redactValue) into a separate file `redactor.ts`.
Updated `safe-logger.ts` to import `redactValue` from the new module.
Exported `redactValue` from the logging barrel in `index.ts` to allow for independent reuse.
Added comprehensive unit tests in `redactor.test.ts`.

This refactoring improves maintainability and testability by separating redaction concerns from the core logging infrastructure.

---
Created from Jules session `sessions/16629096340709802556`
Jules URL: https://jules.google.com/session/16629096340709802556

## Summary by Sourcery

Extract redaction logic into a dedicated utility module and wire it through the logging barrel for reuse.

Enhancements:
- Move sensitive-data redaction regexes and helper into a standalone redactor module, decoupling it from the core safe logger.
- Re-export the redaction utility from the logging index to enable reuse by other modules.

Tests:
- Add unit tests for the redaction utility to validate masking of sensitive fields and bearer tokens.