### PR TITLE
🔒 [security] Fix incomplete data redaction in logger fallback

### DIFF
--- a/mcp-server/src/core/logging/safe-logger.ts
+++ b/mcp-server/src/core/logging/safe-logger.ts
@@ -228,8 +228,8 @@ export function formatMessage(args: unknown[]): string {
           return JSON.stringify(arg, redactValue, 2);
         } catch {
           // Fallback to basic string representation if stringify fails
-          // We can't easily redact here without string parsing, but this case is rare (circular refs)
-          return String(arg);
+          // Ensure we still redact sensitive patterns in the string representation
+          return String(redactValue('', String(arg)));
         }
       }
       // Handle primitive strings that might contain sensitive data


### PR DESCRIPTION
🔒 [security] Fix incomplete data redaction in logger fallback

This commit addresses a security vulnerability in `mcp-server/src/core/logging/safe-logger.ts` where sensitive information (e.g., Bearer tokens, API keys) could be leaked in log files if an object failed to be stringified (e.g., due to circular references).

Changes:
- Wrapped the fallback `String(arg)` call in the `formatMessage` function with `redactValue('', ...)` to ensure that sensitive patterns are redacted even in the fallback string representation.

Verified with a reproduction script that triggers the fallback case using a circular reference with a sensitive `toString()` output.

---
Created from Jules session `sessions/4514721507128244481`
Jules URL: https://jules.google.com/session/4514721507128244481

## Summary by Sourcery

Bug Fixes:
- Prevent potential leakage of sensitive information in log messages when falling back to basic string conversion after JSON stringification errors.