### PR TITLE
⚡ Optimize historical transfers with batching

### DIFF
--- a/mcp-server/src/core/api/actual-client.ts
+++ b/mcp-server/src/core/api/actual-client.ts
@@ -39,6 +39,8 @@ import {
   invalidateNameResolutionState,
 } from './actual-client/cache-helpers.js';
 import {
+  getAllPotentialHistoricalTransferCounterparts,
+  getBatchHistoricalTransferTransactions,
   getHistoricalTransferCounterpartIds,
   getHistoricalTransferInternalLayer,
   isValidHistoricalTransferTransaction,
@@ -1267,8 +1269,32 @@ export async function applyHistoricalTransfers(
         .filter((payee) => typeof payee.transfer_acct === 'string' && payee.transfer_acct)
         .map((payee) => [payee.transfer_acct as string, payee.id]),
     );
+
+    const allRequestedTransactionIds = uniqueCandidateIds.flatMap((id) =>
+      parseHistoricalTransferCandidateId(id),
+    );
+    const allTransactions = await getBatchHistoricalTransferTransactions(
+      db,
+      allRequestedTransactionIds,
+    );
+    const transactionsById = new Map(allTransactions.map((tx) => [tx.id, tx]));
+
+    const validTransactionsForCounterpartSearch = allTransactions.filter(
+      isValidHistoricalTransferTransaction,
+    );
+    const potentialCounterpartsMap = await getAllPotentialHistoricalTransferCounterparts(
+      db,
+      validTransactionsForCounterpartSearch,
+    );
+
     const reservedTransactionIds = new Set<string>();
     const results: HistoricalTransferApplyCandidateResult[] = [];
+    const pendingUpdates: Array<{
+      id: string;
+      payee: string;
+      transfer_id: string;
+      category?: null;
+    }> = [];
 
     for (const candidateId of uniqueCandidateIds) {
       try {
@@ -1288,14 +1314,12 @@ export async function applyHistoricalTransfers(
           continue;
         }
 
-        const [firstTransaction, secondTransaction] = await Promise.all([
-          db.getTransaction(firstTransactionId),
-          db.getTransaction(secondTransactionId),
-        ]);
+        const firstTransaction = transactionsById.get(firstTransactionId);
+        const secondTransaction = transactionsById.get(secondTransactionId);
 
         if (
-          !isValidHistoricalTransferTransaction(firstTransaction) ||
-          !isValidHistoricalTransferTransaction(secondTransaction)
+          !isValidHistoricalTransferTransaction(firstTransaction ?? null) ||
+          !isValidHistoricalTransferTransaction(secondTransaction ?? null)
         ) {
           results.push({
             candidateId,
@@ -1307,50 +1331,52 @@ export async function applyHistoricalTransfers(
           continue;
         }
 
-        if (firstTransaction.account === secondTransaction.account) {
+        // TypeScript safety (isValidHistoricalTransferTransaction already checked for null)
+        const firstTx = firstTransaction!;
+        const secondTx = secondTransaction!;
+
+        if (firstTx.account === secondTx.account) {
           results.push({
             candidateId,
-            transactionIds: [firstTransaction.id, secondTransaction.id],
+            transactionIds: [firstTx.id, secondTx.id],
             status: 'rejected',
             reason: 'Historical transfer pairs must come from different accounts.',
           });
           continue;
         }
 
-        if (firstTransaction.amount !== secondTransaction.amount * -1) {
+        if (firstTx.amount !== secondTx.amount * -1) {
           results.push({
             candidateId,
-            transactionIds: [firstTransaction.id, secondTransaction.id],
+            transactionIds: [firstTx.id, secondTx.id],
             status: 'rejected',
             reason: 'Historical transfer pairs must have exact inverse amounts.',
           });
           continue;
         }
 
-        if (Math.abs(getDateDiffInDays(firstTransaction.date, secondTransaction.date)) > 3) {
+        if (Math.abs(getDateDiffInDays(firstTx.date, secondTx.date)) > 3) {
           results.push({
             candidateId,
-            transactionIds: [firstTransaction.id, secondTransaction.id],
+            transactionIds: [firstTx.id, secondTx.id],
             status: 'rejected',
             reason: 'Historical transfer pairs must fall within 3 days of each other.',
           });
           continue;
         }
 
-        const [firstCounterpartIds, secondCounterpartIds] = await Promise.all([
-          getHistoricalTransferCounterpartIds(db, firstTransaction),
-          getHistoricalTransferCounterpartIds(db, secondTransaction),
-        ]);
+        const firstCounterpartIds = potentialCounterpartsMap.get(firstTx.id) ?? [];
+        const secondCounterpartIds = potentialCounterpartsMap.get(secondTx.id) ?? [];
 
         if (
           firstCounterpartIds.length !== 1 ||
-          firstCounterpartIds[0] !== secondTransaction.id ||
+          firstCounterpartIds[0] !== secondTx.id ||
           secondCounterpartIds.length !== 1 ||
-          secondCounterpartIds[0] !== firstTransaction.id
+          secondCounterpartIds[0] !== firstTx.id
         ) {
           results.push({
             candidateId,
-            transactionIds: [firstTransaction.id, secondTransaction.id],
+            transactionIds: [firstTx.id, secondTx.id],
             status: 'rejected',
             reason:
               'This candidate no longer has a unique exact inverse counterpart, so it cannot be linked safely.',
@@ -1358,47 +1384,44 @@ export async function applyHistoricalTransfers(
           continue;
         }
 
-        const firstTransferPayeeId = transferPayeeByAccountId.get(secondTransaction.account);
-        const secondTransferPayeeId = transferPayeeByAccountId.get(firstTransaction.account);
+        const firstTransferPayeeId = transferPayeeByAccountId.get(secondTx.account);
+        const secondTransferPayeeId = transferPayeeByAccountId.get(firstTx.account);
 
         if (!firstTransferPayeeId || !secondTransferPayeeId) {
           results.push({
             candidateId,
-            transactionIds: [firstTransaction.id, secondTransaction.id],
+            transactionIds: [firstTx.id, secondTx.id],
             status: 'rejected',
             reason: 'A required transfer payee was not found for one of the accounts in this pair.',
           });
           continue;
         }
 
-        const firstAccount = accountsById.get(firstTransaction.account);
-        const secondAccount = accountsById.get(secondTransaction.account);
+        const firstAccount = accountsById.get(firstTx.account);
+        const secondAccount = accountsById.get(secondTx.account);
         const categoriesCleared =
           Boolean(firstAccount?.offbudget) === Boolean(secondAccount?.offbudget);
 
-        await send('transactions-batch-update', {
-          updated: [
-            {
-              id: firstTransaction.id,
-              payee: firstTransferPayeeId,
-              transfer_id: secondTransaction.id,
-              ...(categoriesCleared ? { category: null } : {}),
-            },
-            {
-              id: secondTransaction.id,
-              payee: secondTransferPayeeId,
-              transfer_id: firstTransaction.id,
-              ...(categoriesCleared ? { category: null } : {}),
-            },
-          ],
-          runTransfers: false,
-        });
+        pendingUpdates.push(
+          {
+            id: firstTx.id,
+            payee: firstTransferPayeeId,
+            transfer_id: secondTx.id,
+            ...(categoriesCleared ? { category: null } : {}),
+          },
+          {
+            id: secondTx.id,
+            payee: secondTransferPayeeId,
+            transfer_id: firstTx.id,
+            ...(categoriesCleared ? { category: null } : {}),
+          },
+        );
 
-        reservedTransactionIds.add(firstTransaction.id);
-        reservedTransactionIds.add(secondTransaction.id);
+        reservedTransactionIds.add(firstTx.id);
+        reservedTransactionIds.add(secondTx.id);
         results.push({
           candidateId,
-          transactionIds: [firstTransaction.id, secondTransaction.id],
+          transactionIds: [firstTx.id, secondTx.id],
           status: 'applied',
           categoriesCleared,
         });
@@ -1420,7 +1443,12 @@ export async function applyHistoricalTransfers(
       }
     }
 
-    if (results.some((result) => result.status === 'applied')) {
+    if (pendingUpdates.length > 0) {
+      await send('transactions-batch-update', {
+        updated: pendingUpdates,
+        runTransfers: false,
+      });
+
       cacheService.invalidatePattern('transactions:*');
       cacheService.invalidate('accounts:all');
       invalidateNameResolutionState();

--- a/mcp-server/src/core/api/actual-client/historical-transfers.ts
+++ b/mcp-server/src/core/api/actual-client/historical-transfers.ts
@@ -26,11 +26,11 @@ export function isValidHistoricalTransferTransaction(
 ): transaction is HistoricalTransferInternalTransaction {
   return Boolean(
     transaction &&
-    !transaction.tombstone &&
-    !transaction.starting_balance_flag &&
-    !transaction.is_parent &&
-    !transaction.is_child &&
-    !transaction.transfer_id,
+      !transaction.tombstone &&
+      !transaction.starting_balance_flag &&
+      !transaction.is_parent &&
+      !transaction.is_child &&
+      !transaction.transfer_id,
   );
 }
 
@@ -61,4 +61,93 @@ export async function getHistoricalTransferCounterpartIds(
   )) as Array<{ id: string }>;
 
   return rows.map((row) => row.id);
+}
+
+export async function getBatchHistoricalTransferTransactions(
+  db: NonNullable<NonNullable<NonNullable<ExtendedActualApi['internal']>['db']>>,
+  ids: string[],
+): Promise<HistoricalTransferInternalTransaction[]> {
+  if (ids.length === 0) return [];
+
+  const uniqueIds = [...new Set(ids)];
+  const results: HistoricalTransferInternalTransaction[] = [];
+  const chunkSize = 100;
+
+  for (let i = 0; i < uniqueIds.length; i += chunkSize) {
+    const chunk = uniqueIds.slice(i, i + chunkSize);
+    const placeholders = chunk.map(() => '?').join(',');
+    const rows = (await db.all(
+      `SELECT * FROM v_transactions WHERE id IN (${placeholders})`,
+      chunk,
+    )) as HistoricalTransferInternalTransaction[];
+    results.push(...rows);
+  }
+
+  return results;
+}
+
+export async function getAllPotentialHistoricalTransferCounterparts(
+  db: NonNullable<NonNullable<NonNullable<ExtendedActualApi['internal']>['db']>>,
+  transactions: HistoricalTransferInternalTransaction[],
+): Promise<Map<string, string[]>> {
+  if (transactions.length === 0) return new Map();
+
+  const amounts = [...new Set(transactions.map((tx) => tx.amount * -1))];
+  const minDate = transactions.reduce(
+    (min, tx) => (tx.date < min ? tx.date : min),
+    transactions[0].date,
+  );
+  const maxDate = transactions.reduce(
+    (max, tx) => (tx.date > max ? tx.date : max),
+    transactions[0].date,
+  );
+
+  const windowMinDate = toActualDbDate(shiftDateByDays(minDate, -3));
+  const windowMaxDate = toActualDbDate(shiftDateByDays(maxDate, 3));
+
+  const resultsMap = new Map<string, string[]>();
+  const chunkSize = 100;
+  let allRows: Array<{ id: string; account: string; amount: number; date: string }> = [];
+
+  for (let i = 0; i < amounts.length; i += chunkSize) {
+    const chunk = amounts.slice(i, i + chunkSize);
+    const placeholders = chunk.map(() => '?').join(',');
+    const rows = (await db.all(
+      `SELECT id, account, amount, date
+         FROM v_transactions
+        WHERE tombstone = 0
+          AND (starting_balance_flag = 0 OR starting_balance_flag IS NULL)
+          AND (is_parent = 0 OR is_parent IS NULL)
+          AND (is_child = 0 OR is_child IS NULL)
+          AND transfer_id IS NULL
+          AND amount IN (${placeholders})
+          AND date >= ?
+          AND date <= ?`,
+      [...chunk, windowMinDate, windowMaxDate],
+    )) as Array<{ id: string; account: string; amount: number; date: string }>;
+    allRows.push(...rows);
+  }
+
+  for (const tx of transactions) {
+    const targetAmount = tx.amount * -1;
+    const txMinDate = toActualDbDate(shiftDateByDays(tx.date, -3));
+    const txMaxDate = toActualDbDate(shiftDateByDays(tx.date, 3));
+
+    const matches = allRows
+        .filter((row) => {
+          const rowDbDate = toActualDbDate(row.date);
+          return (
+          row.id !== tx.id &&
+          row.account !== tx.account &&
+          row.amount === targetAmount &&
+            rowDbDate >= txMinDate &&
+            rowDbDate <= txMaxDate
+          );
+        })
+      .map((row) => row.id);
+
+    resultsMap.set(tx.id, matches);
+  }
+
+  return resultsMap;
 }

--- a/mcp-server/src/core/api/actual-client/types.ts
+++ b/mcp-server/src/core/api/actual-client/types.ts
@@ -24,7 +24,7 @@ export type ExtendedActualApi = typeof api & {
     send?: (name: string, args: Record<string, unknown>) => Promise<unknown>;
     db?: {
       getTransaction?: (id: string) => Promise<HistoricalTransferInternalTransaction | null>;
-      all?: (sql: string, params: unknown[]) => Promise<Array<{ id: string }>>;
+      all?: (sql: string, params: unknown[]) => Promise<any[]>;
     };
   };
 };


### PR DESCRIPTION
⚡ Optimize historical transfers with batching

Resolved the N+1 query issue in `applyHistoricalTransfers` by implementing
batched transaction fetching and counterpart matching.

- Added `getBatchHistoricalTransferTransactions` to fetch multiple transactions.
- Added `getAllPotentialHistoricalTransferCounterparts` for bulk matching.
- Consolidated individual transaction updates into a single batch call.
- Significantly reduced database I/O and network round-trips.

---
Created from Jules session `sessions/6631833727042053854`
Jules URL: https://jules.google.com/session/6631833727042053854

## Summary by Sourcery

Batch database access and counterpart lookup for historical transfer application to eliminate N+1 queries and consolidate transaction updates.

Enhancements:
- Preload all candidate historical transfer transactions and reuse them instead of fetching each pair individually.
- Introduce a bulk query to retrieve all potential historical transfer counterparts within date and amount windows.
- Aggregate all transaction transfer-link updates into a single batched update call after processing candidates.
- Relax the database type of the internal `db.all` helper to support the new bulk query shapes.