### PR TITLE
🔒 [security fix] centralize and apply redaction to configuration logs

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -14,6 +14,7 @@ import {
   shutdownActualApi,
   startBackgroundRetry,
 } from './core/api/actual-client.js';
+import { redactValue } from './core/logging/index.js';
 import {
   validateActualAuthStartupConfig,
   shouldWarnAboutAutoSyncForRemote,
@@ -72,21 +73,25 @@ function validateEnv(): void {
     }
   }
   console.error(`  ACTUAL_SERVER_URL: ${serverHostname}`);
-  console.error(`  ACTUAL_PASSWORD: ${process.env.ACTUAL_PASSWORD ? '****' : '(not set)'}`);
   console.error(
-    `  ACTUAL_SESSION_TOKEN: ${process.env.ACTUAL_SESSION_TOKEN ? '****' : '(not set)'}`,
+    `  ACTUAL_PASSWORD: ${redactValue('ACTUAL_PASSWORD', process.env.ACTUAL_PASSWORD) || '(not set)'}`,
+  );
+  console.error(
+    `  ACTUAL_SESSION_TOKEN: ${redactValue('ACTUAL_SESSION_TOKEN', process.env.ACTUAL_SESSION_TOKEN) || '(not set)'}`,
   );
   console.error(
     `  ACTUAL_BUDGET_SYNC_ID: ${process.env.ACTUAL_BUDGET_SYNC_ID ? '(set)' : '(auto-detect)'}`,
   );
   console.error(
-    `  ACTUAL_BUDGET_ENCRYPTION_PASSWORD: ${process.env.ACTUAL_BUDGET_ENCRYPTION_PASSWORD ? '****' : '(not set)'}`,
+    `  ACTUAL_BUDGET_ENCRYPTION_PASSWORD: ${redactValue('ACTUAL_BUDGET_ENCRYPTION_PASSWORD', process.env.ACTUAL_BUDGET_ENCRYPTION_PASSWORD) || '(not set)'}`,
   );
   console.error(`  ACTUAL_DATA_DIR: ${process.env.ACTUAL_DATA_DIR || '(default)'}`);
   console.error(
     `  AUTO_SYNC_INTERVAL_MINUTES: ${process.env.AUTO_SYNC_INTERVAL_MINUTES || '(disabled)'}`,
   );
-  console.error(`  BEARER_TOKEN: ${process.env.BEARER_TOKEN ? '****' : '(not set)'}`);
+  console.error(
+    `  BEARER_TOKEN: ${redactValue('BEARER_TOKEN', process.env.BEARER_TOKEN) || '(not set)'}`,
+  );
   console.error('---');
 }
 


### PR DESCRIPTION
🔒 [security fix] centralize and apply redaction to configuration logs

- Extract redaction logic to mcp-server/src/core/logging/redactor.ts
- Update mcp-server/src/index.ts to use redactValue for sensitive environment variables
- Ensure consistent masking of passwords and tokens in startup logs
- Improve redactValue to handle null/undefined values correctly for logging defaults

---
Created from Jules session `sessions/6953980721529971381`
Jules URL: https://jules.google.com/session/6953980721529971381

## Summary by Sourcery

Centralize sensitive-data redaction for logging and apply it to configuration startup logs.

New Features:
- Introduce a shared redaction utility for masking sensitive values in logs.

Bug Fixes:
- Apply consistent redaction to environment-based configuration logs, including passwords and tokens.

Enhancements:
- Export the redaction helper from the logging module for reuse across the server.
- Improve redaction handling of null and undefined values to avoid misleading log output.