### PR TITLE
ci: scheduled Render MCP health ping (keep-warm)

### DIFF
--- a/.github/workflows/render-mcp-keep-warm.yml
+++ b/.github/workflows/render-mcp-keep-warm.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   ping:
     name: Ping health endpoint
-    runs-on: ubuntu-latest
+    timeout-minutes: 8
     timeout-minutes: 5
     permissions: {}
     steps:

--- a/.github/workflows/render-mcp-keep-warm.yml
+++ b/.github/workflows/render-mcp-keep-warm.yml
@@ -1,0 +1,62 @@
+# Optional: periodic HTTP ping so a Render free/spin-down web service sees traffic
+# and is less likely to stay cold between real MCP clients. This does not replace
+# a paid always-on instance; it only triggers lightweight GETs from GitHub-hosted runners.
+#
+# Setup (repository Settings → Secrets and variables → Actions → Variables):
+#   RENDER_MCP_HEALTH_URL = https://your-service.onrender.com/health
+#
+# If the variable is unset, scheduled runs still appear in Actions but the job is skipped.
+
+name: Render MCP keep-warm
+
+on:
+  schedule:
+    # Every 10 minutes UTC (adjust if you want fewer Actions minutes)
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: render-mcp-keep-warm
+  cancel-in-progress: true
+
+jobs:
+  ping:
+    name: Ping health endpoint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ vars.RENDER_MCP_HEALTH_URL != '' }}
+    permissions: {}
+    steps:
+      - name: Warm Render instance
+        env:
+          HEALTH_URL: ${{ vars.RENDER_MCP_HEALTH_URL }}
+        run: |
+          set -euo pipefail
+          max_attempts=6
+          sleep_seconds=15
+
+          for attempt in $(seq 1 "$max_attempts"); do
+            http_code=$(
+              curl -sS -o /tmp/health.json -w '%{http_code}' \
+                --connect-timeout 20 --max-time 60 \
+                "$HEALTH_URL" || true
+            )
+            if [ -z "$http_code" ]; then
+              http_code=000
+            fi
+
+            if [ "$http_code" = "200" ]; then
+              echo "Health OK (attempt ${attempt}/${max_attempts})"
+              cat /tmp/health.json
+              echo
+              exit 0
+            fi
+
+            echo "Attempt ${attempt}/${max_attempts}: HTTP ${http_code}"
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              sleep "$sleep_seconds"
+            fi
+          done
+
+          echo "Health check failed after ${max_attempts} attempts"
+          exit 1

--- a/.github/workflows/render-mcp-keep-warm.yml
+++ b/.github/workflows/render-mcp-keep-warm.yml
@@ -58,8 +58,8 @@ jobs:
 
             if [ "$http_code" = "200" ]; then
               echo "Health OK (attempt ${attempt}/${max_attempts})"
-              cat /tmp/health.json
-              echo
+              health_size=$(wc -c < /tmp/health.json 2>/dev/null || echo "unknown")
+              echo "Health response size: ${health_size} bytes"
               exit 0
             fi
 

--- a/.github/workflows/render-mcp-keep-warm.yml
+++ b/.github/workflows/render-mcp-keep-warm.yml
@@ -2,10 +2,11 @@
 # and is less likely to stay cold between real MCP clients. This does not replace
 # a paid always-on instance; it only triggers lightweight GETs from GitHub-hosted runners.
 #
-# Setup (repository Settings → Secrets and variables → Actions → Variables):
-#   RENDER_MCP_HEALTH_URL = https://your-service.onrender.com/health
+# Setup (repository Settings → Secrets and variables → Actions):
+#   Secret: RENDER_MCP_HEALTH_URL = https://your-service.onrender.com/health
+#   (Optional) Variable with the same name is used if the secret is unset.
 #
-# If the variable is unset, scheduled runs still appear in Actions but the job is skipped.
+# /health is unauthenticated; a secret is optional but fine if you prefer not to expose the URL in variables.
 
 name: Render MCP keep-warm
 
@@ -24,14 +25,24 @@ jobs:
     name: Ping health endpoint
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: ${{ vars.RENDER_MCP_HEALTH_URL != '' }}
     permissions: {}
     steps:
       - name: Warm Render instance
         env:
-          HEALTH_URL: ${{ vars.RENDER_MCP_HEALTH_URL }}
+          HEALTH_URL_SECRET: ${{ secrets.RENDER_MCP_HEALTH_URL }}
+          HEALTH_URL_VAR: ${{ vars.RENDER_MCP_HEALTH_URL }}
         run: |
           set -euo pipefail
+
+          if [ -n "${HEALTH_URL_SECRET:-}" ]; then
+            HEALTH_URL="$HEALTH_URL_SECRET"
+          elif [ -n "${HEALTH_URL_VAR:-}" ]; then
+            HEALTH_URL="$HEALTH_URL_VAR"
+          else
+            echo "Configure RENDER_MCP_HEALTH_URL as a repository secret or variable (Actions settings)."
+            exit 1
+          fi
+
           max_attempts=6
           sleep_seconds=15
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a scheduled GitHub Actions workflow that periodically `GET`s a configurable health URL so a Render-hosted MCP service receives traffic on a cadence. That reduces cold starts between real clients; it does not change Render’s sleep policy for free-tier services.

## Configuration

Use **either** (same name):

- **Secret:** `RENDER_MCP_HEALTH_URL` — e.g. `https://actual-mcp.onrender.com/health` (recommended if you added it as a secret; secrets are not available in job `if:` so the workflow reads the URL inside the step).
- **Variable:** `RENDER_MCP_HEALTH_URL` — same value, if you prefer a non-secret variable.

If neither is set, the job fails with a clear message.

## Notes

- **No bearer token** is required for `/health`.
- Cron is **every 10 minutes**; adjust in the workflow if you want fewer Actions minutes.
- Retries with backoff handle Render **hibernate wake** (503 / empty body).

## Files

- `.github/workflows/render-mcp-keep-warm.yml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91a8cf65-cc2e-43e9-9afa-630114e534e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91a8cf65-cc2e-43e9-9afa-630114e534e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

CI:
- Introduce a scheduled and manually-triggerable workflow that pings a Render MCP health URL every 10 minutes with retry logic, conditioned on a repository variable being set.