### PR TITLE
fix: stabilize Actual Budget connection init (GH #239)

### DIFF
--- a/mcp-server/src/actual-api.test.ts
+++ b/mcp-server/src/actual-api.test.ts
@@ -425,6 +425,10 @@ describe('Auto-load functionality', () => {
   });
 
   describe('single-flight initialization', () => {
+    afterEach(() => {
+      mockInitSuccess();
+    });
+
     it('should reuse the same initialization promise for concurrent callers', async () => {
       process.env.ACTUAL_BUDGET_SYNC_ID = 'test-sync-id';
       process.env.ACTUAL_DATA_DIR = '/test/data';
@@ -448,6 +452,8 @@ describe('Auto-load functionality', () => {
       const firstInit = actualApi.initActualApi();
       const secondInit = actualApi.initActualApi();
 
+      // Let the mutex microtask run so `api.init` runs and assigns `resolveInit` in its executor.
+      await Promise.resolve();
       resolveInit?.();
       await Promise.all([firstInit, secondInit]);
 

--- a/mcp-server/src/core/analysis/financial-analyzer.ts
+++ b/mcp-server/src/core/analysis/financial-analyzer.ts
@@ -3,6 +3,7 @@
 // Server-side analysis to reduce context window load
 // ----------------------------
 
+import '../../polyfill.js';
 import { q } from '@actual-app/api';
 import { getAccounts, getBudgetMonth, getSchedules, runAQL } from '../api/actual-client.js';
 import { fetchAccountBalances } from '../data/fetch-account-balances.js';

--- a/mcp-server/src/core/api/actual-client.ts
+++ b/mcp-server/src/core/api/actual-client.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import '../../polyfill.js';
 import api from '@actual-app/api';
 import type {
   RuleEntity,
@@ -73,7 +74,8 @@ const INITIAL_CONNECTION_STATE: ActualConnectionState = {
 // API initialization state
 let initialized = false;
 let initializationError: Error | null = null;
-let initializationPromise: Promise<void> | null = null;
+/** Serializes init/reconnect/shutdown so concurrent callers cannot interleave or race on shared API state. */
+let initMutexChain: Promise<void> = Promise.resolve();
 let checkingHealth = false; // Prevent recursion in health checks
 let connectionState: ActualConnectionState = { ...INITIAL_CONNECTION_STATE };
 
@@ -263,25 +265,25 @@ async function runReadOperation<T>(
   });
 }
 
-async function waitForInitialization(timeoutMs = 55000): Promise<void> {
-  if (!initializationPromise) {
-    return;
-  }
-
-  let timeoutHandle: NodeJS.Timeout | null = null;
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeoutHandle = setTimeout(() => {
-      reject(new Error(`Initialization timed out after ${Math.floor(timeoutMs / 1000)} seconds`));
-    }, timeoutMs);
+function enqueueInit<T>(work: () => Promise<T>, timeoutMs = 55000): Promise<T> {
+  const next = initMutexChain.then(() => {
+    let timeoutHandle: NodeJS.Timeout | null = null;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => {
+        reject(new Error(`Initialization timed out after ${Math.floor(timeoutMs / 1000)} seconds`));
+      }, timeoutMs);
+    });
+    return Promise.race([work(), timeoutPromise]).finally(() => {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    });
   });
-
-  try {
-    await Promise.race([initializationPromise, timeoutPromise]);
-  } finally {
-    if (timeoutHandle) {
-      clearTimeout(timeoutHandle);
-    }
-  }
+  initMutexChain = next.then(
+    () => {},
+    () => {},
+  );
+  return next;
 }
 
 /**
@@ -488,6 +490,11 @@ function handleInitializationError(error: unknown): never {
     console.error('  1. Update Actual Budget server to the latest version');
     console.error('  2. Restart the Actual Budget service - migrations will auto-apply');
     console.error('  3. If the issue persists, check Actual Budget server logs');
+  } else if (error instanceof Error) {
+    console.error('Failed to initialize Actual Budget API:', errorMessage);
+    if (error.stack) {
+      console.error(error.stack);
+    }
   } else {
     console.error('Failed to initialize Actual Budget API:', error);
   }
@@ -502,33 +509,25 @@ function handleInitializationError(error: unknown): never {
  * @param forceReconnect - If true, force reconnection even if already initialized
  */
 export async function initActualApi(forceReconnect = false): Promise<void> {
-  if (initialized && !forceReconnect) {
-    initializationSkipCount++;
-    if (process.env.PERFORMANCE_LOGGING_ENABLED !== 'false') {
-      const timeSaved = initializationTime || 600;
-      console.error(
-        `[PERF] Initialization skipped (persistent connection) - saved ~${timeSaved}ms (skip count: ${initializationSkipCount})`,
-      );
+  return enqueueInit(async () => {
+    if (initialized && !forceReconnect) {
+      initializationSkipCount++;
+      if (process.env.PERFORMANCE_LOGGING_ENABLED !== 'false') {
+        const timeSaved = initializationTime || 600;
+        console.error(
+          `[PERF] Initialization skipped (persistent connection) - saved ~${timeSaved}ms (skip count: ${initializationSkipCount})`,
+        );
+      }
+      return;
     }
-    return;
-  }
 
-  if (initializationPromise) {
-    await waitForInitialization();
-    if (initializationError) {
-      throw initializationError;
+    if (forceReconnect && process.env.PERFORMANCE_LOGGING_ENABLED !== 'false') {
+      console.error('[CONNECTION] Forcing reconnection...');
     }
-    return;
-  }
 
-  if (forceReconnect && process.env.PERFORMANCE_LOGGING_ENABLED !== 'false') {
-    console.error('[CONNECTION] Forcing reconnection...');
-  }
+    initializationError = null;
+    markConnectionInitializing();
 
-  initializationError = null;
-  markConnectionInitializing();
-
-  initializationPromise = (async () => {
     const startTime = Date.now();
 
     try {
@@ -553,15 +552,8 @@ export async function initActualApi(forceReconnect = false): Promise<void> {
       setupAutoSync();
     } catch (error) {
       handleInitializationError(error);
-    } finally {
-      initializationPromise = null;
     }
-  })();
-
-  await waitForInitialization();
-  if (initializationError) {
-    throw initializationError;
-  }
+  });
 }
 
 /**
@@ -648,37 +640,39 @@ function setupAutoSync(): void {
  * Shutdown the Actual Budget API
  */
 export async function shutdownActualApi(): Promise<void> {
-  // Clean up auto-sync interval
-  if (autoSyncInterval) {
-    clearInterval(autoSyncInterval);
-    autoSyncInterval = null;
-  }
+  await enqueueInit(async () => {
+    // Clean up auto-sync interval
+    if (autoSyncInterval) {
+      clearInterval(autoSyncInterval);
+      autoSyncInterval = null;
+    }
 
-  // Clean up background retry timer
-  if (backgroundRetryTimer) {
-    clearTimeout(backgroundRetryTimer);
-    backgroundRetryTimer = null;
-  }
+    // Clean up background retry timer
+    if (backgroundRetryTimer) {
+      clearTimeout(backgroundRetryTimer);
+      backgroundRetryTimer = null;
+    }
 
-  if (!initialized) {
-    initializationError = null;
-    updateConnectionState({
-      status: 'disconnected',
-    });
-    return;
-  }
+    if (!initialized) {
+      initializationError = null;
+      updateConnectionState({
+        status: 'disconnected',
+      });
+      return;
+    }
 
-  try {
-    await api.shutdown();
-  } catch (error) {
-    console.error('Error shutting down Actual Budget API:', error);
-  } finally {
-    initialized = false;
-    initializationError = null;
-    updateConnectionState({
-      status: 'disconnected',
-    });
-  }
+    try {
+      await api.shutdown();
+    } catch (error) {
+      console.error('Error shutting down Actual Budget API:', error);
+    } finally {
+      initialized = false;
+      initializationError = null;
+      updateConnectionState({
+        status: 'disconnected',
+      });
+    }
+  });
 }
 
 /**
@@ -708,7 +702,7 @@ export function isInitialized(): boolean {
  * Check if the API is currently initializing
  */
 export function isInitializing(): boolean {
-  return initializationPromise !== null || connectionState.status === 'initializing';
+  return connectionState.status === 'initializing';
 }
 
 /**
@@ -803,10 +797,6 @@ function isConnectionError(errorMessage: string): boolean {
 }
 
 async function ensureReadConnectionAvailable(): Promise<void> {
-  if (initializationPromise) {
-    await waitForInitialization();
-  }
-
   if (initialized && connectionState.status === 'ready') {
     return;
   }
@@ -815,10 +805,6 @@ async function ensureReadConnectionAvailable(): Promise<void> {
 }
 
 async function ensureWriteConnectionAvailable(): Promise<void> {
-  if (initializationPromise) {
-    await waitForInitialization();
-  }
-
   if (!initialized || connectionState.status !== 'ready') {
     await initActualApi(connectionState.status === 'error' || initializationError !== null);
   }

--- a/mcp-server/src/core/api/actual-client/types.ts
+++ b/mcp-server/src/core/api/actual-client/types.ts
@@ -1,3 +1,4 @@
+import '../../../polyfill.js';
 import api from '@actual-app/api';
 import type {
   APIAccountEntity,

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import './polyfill.js';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/mcp-server/src/polyfill.ts
+++ b/mcp-server/src/polyfill.ts
@@ -1,0 +1,10 @@
+// Polyfill browser globals required by @actual-app/api at module load time.
+// navigator.platform is referenced at the top level of bundle.api.js; Node.js
+// has no navigator global so the process crashes on startup without this.
+// Import this module before any `@actual-app/api` import in ESM entrypoints.
+if (typeof globalThis.navigator === 'undefined') {
+  globalThis.navigator = {
+    platform: process.platform,
+    userAgent: 'node',
+  } as unknown as Navigator;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [issue #239](https://github.com/guitarbeat/Actual-MCP-Server/issues/239): budget briefly becomes ready then drops, with reconnect loops that feel flaky under concurrent HTTP/MCP traffic.

## Changes

- **Serialized init/reconnect/shutdown** with a single promise chain (`enqueueInit`) so concurrent `initActualApi` callers cannot interleave `api.init` / `downloadBudget` / `shutdown` on shared `@actual-app/api` state.
- **Removed** the `initializationPromise` + `finally { initializationPromise = null }` pattern that could race with waiters.
- **ESM `navigator` polyfill** in `mcp-server/src/polyfill.ts`, imported at server entry and before `@actual-app/api` in modules that load the API at import time (`actual-client.ts`, `actual-client/types.ts`, `financial-analyzer.ts`), so Node runs match Docker `--require` behavior even when preload is omitted.
- **Richer logging** for non-migration init failures (message + stack when `Error`).
- **Test fix**: single-flight test now `await Promise.resolve()` before calling `resolveInit`, and restores `mockInitSuccess` in `afterEach` so the hanging `api.init` mock does not poison later tests.

## Verification

- `pnpm --filter actual-mcp quality`
- `pnpm --filter actual-mcp test`
- `pnpm --filter actual-mcp build`
- `pnpm --filter actual-mcp test:startup-smoke`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af8235e3-d2f0-49f9-969e-ac15acb7b0aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af8235e3-d2f0-49f9-969e-ac15acb7b0aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Serialize Actual Budget API initialization and shutdown to prevent concurrent connection races and improve startup stability.

Bug Fixes:
- Prevent concurrent init/reconnect/shutdown calls from interleaving on shared Actual API state, avoiding flaky reconnect loops and transient ready states.
- Fix single-flight initialization test flakiness by ensuring mocks are reset and async resolution ordering is deterministic.

Enhancements:
- Add a mutex-style initialization queue with timeouts to enforce serialized connection lifecycle operations.
- Improve logging for non-migration initialization failures by including error messages and stacks when available.
- Introduce an ESM-friendly navigator polyfill to align Node.js runtime behavior with Docker preload configuration for @actual-app/api consumers.

Tests:
- Adjust single-flight initialization tests to account for microtask timing and restore init mocks after each test to avoid cross-test interference.