### PR TITLE
🧪 [Testing Improvement] Add test for untested error path in assertUuid

### DIFF
--- a/mcp-server/src/core/api/actual-client.ts
+++ b/mcp-server/src/core/api/actual-client.ts
@@ -21,6 +21,7 @@ import type {
   ExtendedActualApi,
   HistoricalTransferApplyCandidateResult,
   HistoricalTransferApplyResult,
+  HistoricalTransferInternalTransaction,
 } from './actual-client/types.js';
 import {
   getDateDiffInDays,

--- a/mcp-server/src/core/input/validators.test.ts
+++ b/mcp-server/src/core/input/validators.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   assertMonth,
   assertPositiveIntegerCents,
@@ -7,6 +7,7 @@ import {
   validateDate,
   validateMonth,
   validateUUID,
+  UUIDSchema,
 } from './validators.js';
 
 describe('validators', () => {
@@ -121,6 +122,16 @@ describe('validators', () => {
 
     it('throws an error if value is not a string type', () => {
       expect(() => assertUuid(123, 'userId')).toThrow('userId must be a valid UUID');
+    });
+
+    it('re-throws non-Zod errors', () => {
+      const mockError = new Error('Some unexpected error');
+      const spy = vi.spyOn(UUIDSchema, 'parse').mockImplementation(() => {
+        throw mockError;
+      });
+
+      expect(() => assertUuid('123e4567-e89b-12d3-a456-426614174000', 'userId')).toThrow(mockError);
+      spy.mockRestore();
     });
   });
 

--- a/mcp-server/src/core/logging/safe-logger.ts
+++ b/mcp-server/src/core/logging/safe-logger.ts
@@ -35,7 +35,6 @@ const performanceEnabled = process.env.DEBUG_PERFORMANCE === 'true';
 const performanceMetrics: Map<string, { start: number; end?: number; duration?: number }> =
   new Map();
 
-
 /**
  * Setup safe logging for stdio mode.
  * Overrides console methods to route logs through MCP logging protocol,


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The catch block in `assertUuid` correctly handled `ZodError` exceptions but lacked test coverage for re-throwing other generic non-Zod errors.

📊 **Coverage:** What scenarios are now tested
A new test using Vitest's `vi.spyOn` explicitly mocks `UUIDSchema.parse` to throw a standard `Error`. This guarantees that if underlying validation throws a non-Zod error, it is re-thrown untouched.

✨ **Result:** The improvement in test coverage
The previously untested error path is now fully covered, improving the overall reliability of the validation utility.

---
*PR created automatically by Jules for task [5561853395153697392](https://jules.google.com/task/5561853395153697392) started by @guitarbeat*