### PR TITLE
🧪 Improve assertMonth test coverage with property-based testing

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,5 @@
+🎯 **What:** The testing gap addressed in `assertMonth` (missing property tests, whitespace handling, and invalid months).
+
+📊 **Coverage:** Added fast-check property tests to cover all valid YYYY-MM strings and assert rejection of arbitrarily invalid strings. Added unit test coverage for valid strings surrounded by whitespace and for non-existent month values.
+
+✨ **Result:** The improvement in test coverage resulted in discovering a bug where `assertMonth` failed to trim strings before running schema validation. The bug has been fixed.

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,5 +1,0 @@
-🎯 **What:** The testing gap addressed in `assertMonth` (missing property tests, whitespace handling, and invalid months).
-
-📊 **Coverage:** Added fast-check property tests to cover all valid YYYY-MM strings and assert rejection of arbitrarily invalid strings. Added unit test coverage for valid strings surrounded by whitespace and for non-existent month values.
-
-✨ **Result:** The improvement in test coverage resulted in discovering a bug where `assertMonth` failed to trim strings before running schema validation. The bug has been fixed.

--- a/mcp-server/src/core/api/actual-client.ts
+++ b/mcp-server/src/core/api/actual-client.ts
@@ -21,6 +21,7 @@ import type {
   ExtendedActualApi,
   HistoricalTransferApplyCandidateResult,
   HistoricalTransferApplyResult,
+  HistoricalTransferInternalTransaction,
 } from './actual-client/types.js';
 import {
   getDateDiffInDays,
@@ -53,6 +54,7 @@ export type {
   ActualReadinessStatus,
   ActualReadinessStatusExtended,
   HistoricalTransferApplyResult,
+  HistoricalTransferInternalTransaction,
 } from './actual-client/types.js';
 
 const extendedApi: ExtendedActualApi = api as ExtendedActualApi;

--- a/mcp-server/src/core/input/validators.test.ts
+++ b/mcp-server/src/core/input/validators.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import fc from 'fast-check';
 import {
   assertMonth,
   assertPositiveIntegerCents,
@@ -129,6 +130,10 @@ describe('validators', () => {
       expect(assertMonth('2023-10', 'billingMonth')).toBe('2023-10');
     });
 
+    it('returns the month if it is valid but surrounded by whitespace', () => {
+      expect(assertMonth('  2023-10  ', 'billingMonth')).toBe('2023-10');
+    });
+
     it('throws an error if value is null or undefined', () => {
       expect(() => assertMonth(null, 'billingMonth')).toThrow(
         'billingMonth is required and must be in YYYY-MM format',
@@ -156,9 +161,50 @@ describe('validators', () => {
       );
     });
 
+    it('throws an error for non-existent month values', () => {
+      expect(() => assertMonth('2023-00', 'billingMonth')).toThrow(
+        'billingMonth must be in YYYY-MM format',
+      );
+    });
+
     it('throws an error if value is not a string type', () => {
       expect(() => assertMonth(123, 'billingMonth')).toThrow(
         'billingMonth must be in YYYY-MM format',
+      );
+    });
+  });
+
+  describe('assertMonth property tests', () => {
+    it('accepts any valid YYYY-MM string', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 1000, max: 9999 }),
+          fc.integer({ min: 1, max: 12 }),
+          (year, month) => {
+            const paddedMonth = month.toString().padStart(2, '0');
+            const validMonthString = `${year}-${paddedMonth}`;
+            expect(assertMonth(validMonthString, 'billingMonth')).toBe(validMonthString);
+          },
+        ),
+      );
+    });
+
+    it('rejects improperly formatted strings', () => {
+      fc.assert(
+        fc.property(
+          fc.string().filter((s) => !/^\d{4}-(0[1-9]|1[0-2])$/.test(s.trim())),
+          (invalidString) => {
+            if (invalidString.trim() === '') {
+              expect(() => assertMonth(invalidString, 'billingMonth')).toThrow(
+                'billingMonth is required and must be in YYYY-MM format',
+              );
+            } else {
+              expect(() => assertMonth(invalidString, 'billingMonth')).toThrow(
+                'billingMonth must be in YYYY-MM format',
+              );
+            }
+          },
+        ),
       );
     });
   });

--- a/mcp-server/src/core/input/validators.ts
+++ b/mcp-server/src/core/input/validators.ts
@@ -110,7 +110,7 @@ export function assertMonth(value: unknown, fieldName: string): string {
   }
 
   try {
-    return MonthSchema.parse(value);
+    return typeof value === 'string' ? MonthSchema.parse(value.trim()) : MonthSchema.parse(value);
   } catch (error) {
     if (error instanceof z.ZodError) {
       throw new Error(`${fieldName} must be in YYYY-MM format`);

--- a/mcp-server/src/core/logging/safe-logger.ts
+++ b/mcp-server/src/core/logging/safe-logger.ts
@@ -35,7 +35,6 @@ const performanceEnabled = process.env.DEBUG_PERFORMANCE === 'true';
 const performanceMetrics: Map<string, { start: number; end?: number; duration?: number }> =
   new Map();
 
-
 /**
  * Setup safe logging for stdio mode.
  * Overrides console methods to route logs through MCP logging protocol,


### PR DESCRIPTION
🎯 **What:** The testing gap addressed in `assertMonth` (missing property tests, whitespace handling, and invalid months).

📊 **Coverage:** Added fast-check property tests to cover all valid YYYY-MM strings and assert rejection of arbitrarily invalid strings. Added unit test coverage for valid strings surrounded by whitespace and for non-existent month values. 

✨ **Result:** The improvement in test coverage resulted in discovering a bug where `assertMonth` failed to trim strings before running schema validation. The bug has been fixed.

---
*PR created automatically by Jules for task [7865170075102063350](https://jules.google.com/task/7865170075102063350) started by @guitarbeat*