### PR TITLE
🔒 Fix incomplete secret redaction for Bearer tokens in logger

### DIFF
--- a/mcp-server/src/core/api/actual-client.ts
+++ b/mcp-server/src/core/api/actual-client.ts
@@ -21,6 +21,7 @@ import type {
   ExtendedActualApi,
   HistoricalTransferApplyCandidateResult,
   HistoricalTransferApplyResult,
+  HistoricalTransferInternalTransaction,
 } from './actual-client/types.js';
 import {
   getDateDiffInDays,
@@ -53,6 +54,7 @@ export type {
   ActualReadinessStatus,
   ActualReadinessStatusExtended,
   HistoricalTransferApplyResult,
+  HistoricalTransferInternalTransaction,
 } from './actual-client/types.js';
 
 const extendedApi: ExtendedActualApi = api as ExtendedActualApi;

--- a/mcp-server/src/core/logging/safe-logger.ts
+++ b/mcp-server/src/core/logging/safe-logger.ts
@@ -35,7 +35,6 @@ const performanceEnabled = process.env.DEBUG_PERFORMANCE === 'true';
 const performanceMetrics: Map<string, { start: number; end?: number; duration?: number }> =
   new Map();
 
-
 /**
  * Setup safe logging for stdio mode.
  * Overrides console methods to route logs through MCP logging protocol,

--- a/mcp-server/src/core/response/response-builder.test.ts
+++ b/mcp-server/src/core/response/response-builder.test.ts
@@ -297,5 +297,37 @@ describe('Response Builder', () => {
         );
       });
     });
+
+    describe('sanitizeLogValue', () => {
+      it('should properly redact Bearer tokens with base64 characters', () => {
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const err = new Error('Test base64 token');
+
+        errorFromCatch(err, {
+          operation: 'testOp',
+          tool: 'testTool',
+          args: {
+            auth: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c=',
+          },
+        });
+
+        expect(consoleSpy).toHaveBeenCalled();
+        const logMessage = consoleSpy.mock.calls[0][0] as string;
+        expect(logMessage).toContain('Bearer [REDACTED]');
+        expect(logMessage).not.toContain('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9');
+      });
+
+      it('should properly redact Bearer tokens using case insensitive matching', () => {
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const err = new Error('Test case insensitive token');
+
+        errorFromCatch(err, {
+          args: { header: 'bearer secret-token' },
+        });
+
+        const logMessage = consoleSpy.mock.calls[0][0] as string;
+        expect(logMessage).toContain('bearer [REDACTED]');
+      });
+    });
   });
 });

--- a/mcp-server/src/core/response/response-builder.ts
+++ b/mcp-server/src/core/response/response-builder.ts
@@ -252,7 +252,7 @@ function formatErrorContext(context: ErrorContext): string {
 
 const SENSITIVE_KEY_REGEX =
   /pass(word|phrase)|(?<!(input|output|max|total)_)token|secret|(private|api|access).?key|authorization|bearer|credential/i;
-const BEARER_TOKEN_REGEX = /Bearer\\s+([a-zA-Z0-9._-]+)/gi;
+const BEARER_TOKEN_REGEX = /(Bearer\s+)[a-zA-Z0-9\-._~+/]+=*/gi;
 const MAX_LOG_STRING_LENGTH = 500;
 const MAX_LOG_DEPTH = 4;
 
@@ -262,7 +262,7 @@ function sanitizeLogValue(value: unknown, depth: number, seen: WeakSet<object>):
   }
 
   if (typeof value === 'string') {
-    const redacted = value.replace(BEARER_TOKEN_REGEX, 'Bearer [REDACTED]');
+    const redacted = value.replace(BEARER_TOKEN_REGEX, '$1[REDACTED]');
     return redacted.length > MAX_LOG_STRING_LENGTH
       ? `${redacted.slice(0, MAX_LOG_STRING_LENGTH)}…`
       : redacted;


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `response-builder.ts` logging code previously used a naive and flawed regular expression to match and redact `Bearer` tokens (`/Bearer\\s+([a-zA-Z0-9._-]+)/gi`). This regex failed to properly match the whitespace and neglected base64/JWT-specific characters like `+`, `/`, `~`, and `=`. This meant that common API credentials could bypass redaction and leak into standard server logs if formatted unexpectedly or when utilizing modern JWT or base64 structures. 

⚠️ **Risk:** The potential impact if left unfixed
If the code remained unfixed, sensitive authorization tokens sent within requests could be captured directly in plaintext logs, enabling credential exfiltration by anyone with access to the system log stream. This can lead to account hijacking or unauthorized access to sensitive financial endpoints.

🛡️ **Solution:** How the fix addresses the vulnerability
The regular expression was updated to robustly match Base64, base64url, and JWT tokens format: `/(Bearer\s+)[a-zA-Z0-9\-._~+/]+=*/gi`. The replacement logic was changed from hardcoding `"Bearer [REDACTED]"` to capturing the dynamic whitespace prefix (`$1[REDACTED]`) to preserve format while strictly stripping the sensitive payload. New security test cases were also authored to ensure `response-builder.test.ts` continually asserts these boundaries against case-insensitive structures and typical JWT token formats.

---
*PR created automatically by Jules for task [5979852147288850636](https://jules.google.com/task/5979852147288850636) started by @guitarbeat*